### PR TITLE
feat: add dual-track recording to capture each side of a call separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It can also be seen as an on-device wrapper for [scrcpy-server](https://github.c
     - Ignore specific contacts
     - Ignore all contacts
 - Saves recordings with **Opus** or **AAC** codec.
+- Optionally records each side of the call (uplink/downlink) as two separate, time-synced files, useful for transcription with clear speaker separation.
 - The app runs only on phone event changes, no persistent background process and notifications
 
 ## Requirements

--- a/app/src/main/aidl/com/kitsumed/shizucallrecorder/IShellService.aidl
+++ b/app/src/main/aidl/com/kitsumed/shizucallrecorder/IShellService.aidl
@@ -41,6 +41,31 @@ interface IShellService {
     void stopRecording() = 3;
 
     /**
+     * Starts a second, independent audio-capture pipeline in parallel with [startRecording].
+     * Used for dual-track recording, where each side of a call (uplink/downlink) is captured
+     * as its own scrcpy-server process and its own pipe, so the two streams never mix.
+     *
+     * @param audioSource        scrcpy audio_source parameter (e.g. "voice-call-downlink").
+     * @param audioCodec         scrcpy audio_codec parameter (e.g. "opus", "aac").
+     * @param audioBitRate       scrcpy audio_bit_rate in bps (e.g. 16000 for 16 kbps Opus).
+     * @param serverPath      Absolute path to scrcpy-server.jar in shared storage.
+     * @param isDebuggingModeEnabled  When true, logs relay throughput every second.
+     * @return The read-end [ParcelFileDescriptor] of the audio pipe, or null on failure.
+     */
+    ParcelFileDescriptor startSecondaryRecording(
+        String audioSource,
+        String audioCodec,
+        int audioBitRate,
+        String serverPath,
+        boolean isDebuggingModeEnabled
+    ) = 7;
+
+    /**
+     * Stops the secondary audio capture pipeline started by [startSecondaryRecording].
+     */
+    void stopSecondaryRecording() = 8;
+
+    /**
      * Grants an AppOp permission at the package level for a specific user profile.
      * @param packageName The package name of the app to grant the permission to.
      * @param opName The AppOp operation name (e.g., "READ_PHONE_STATE").

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/data/AppPreferences.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/data/AppPreferences.kt
@@ -45,6 +45,7 @@ class AppPreferences(context: Context) {
         const val VIBRATION_ENABLED = true
         val CALL_DETECTION_MODE = CallDetectionMode.getDefaultModeForDevice().key
         const val RECORD_THIRD_PARTY_CALLS = false
+        const val DUAL_TRACK_RECORDING_ENABLED = false
 
         const val POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED = false
         const val AUTO_RECORD_INCOMING = false
@@ -123,7 +124,8 @@ class AppPreferences(context: Context) {
         SHIZUKU_KEEP_ALIVE("shizuku_keep_alive"),
         SHIZUKU_AUTH_KEY("shizuku_auth_key"),
         CALL_DETECTION_MODE("call_detection_mode"),
-        RECORD_THIRD_PARTY_CALLS("record_third_party_calls");
+        RECORD_THIRD_PARTY_CALLS("record_third_party_calls"),
+        DUAL_TRACK_RECORDING_ENABLED("dual_track_recording_enabled");
     }
 
     // -------- Nested enums
@@ -376,6 +378,15 @@ class AppPreferences(context: Context) {
 
     /** Sets the configured audio bitrate. */
     fun setAudioBitRate(bitRate: Int) = setInt(Key.AUDIO_BITRATE, bitRate)
+
+    /**
+     * Checks if dual-track recording is enabled. When enabled, each side of the call is captured
+     * separately (uplink/downlink) into two files instead of one, ignoring [getAudioSource].
+     */
+    fun isDualTrackRecordingEnabled() = getBoolean(Key.DUAL_TRACK_RECORDING_ENABLED, DefaultsValue.DUAL_TRACK_RECORDING_ENABLED)
+
+    /** Sets whether dual-track recording is enabled. */
+    fun setDualTrackRecordingEnabled(enabled: Boolean) = setBoolean(Key.DUAL_TRACK_RECORDING_ENABLED, enabled)
 
     // -------- File Naming --------
 

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/integrations/scrcpy/ScrcpyAudioMuxer.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/integrations/scrcpy/ScrcpyAudioMuxer.kt
@@ -37,10 +37,15 @@ import java.nio.ByteBuffer
  *
  * @param outputFileDescriptor Writable [java.io.FileDescriptor] for the output file (from SAF).
  * @param outputDisplayPath    Human-readable path for logs (e.g. "Recordings/call_….ogg").
+ * @param sharedOriginNanos    Optional [System.nanoTime] instant to use as PTS=0 instead of this
+ *                             muxer's own first packet. Used for dual-track recording so both
+ *                             tracks' timelines share the exact same wall-clock origin and stay
+ *                             in sync when merged externally (e.g. for transcription).
  */
 class ScrcpyAudioMuxer(
     private val outputFileDescriptor: java.io.FileDescriptor,
-    private val outputDisplayPath: String
+    private val outputDisplayPath: String,
+    private val sharedOriginNanos: Long? = null
 ) : Closeable {
 
     // Muxer state
@@ -144,7 +149,7 @@ class ScrcpyAudioMuxer(
         // dead time from our internal timeline so the final output file doesn't have a huge silence.
         // TODO: This code was added to fix most phone audio player behaving badly with the large silence, ideally we would like to keep the silence and not corrupt the file by doing so.
         if (firstPacketTimeNanos == -1L) {
-            firstPacketTimeNanos = nowNanos
+            firstPacketTimeNanos = sharedOriginNanos ?: nowNanos
             lastPacketWallClockNanos = nowNanos
             AppLogger.d( "First audio frame: wall-clock origin set, pts=0")
         } else {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/AudioRecordingEngine.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/AudioRecordingEngine.kt
@@ -39,19 +39,45 @@ import kotlinx.coroutines.withTimeoutOrNull
  * Manages the audio recording pipeline, including the connection to the shell service, reading from the audio pipe,
  * parsing scrcpy-server custom stream format, and writing to the output container via [ScrcpyAudioMuxer].
  *
+ * Normally manages a single [TrackSession] (one scrcpy-server capture -> one output file). When the user enables
+ * dual-track recording, it manages two independent [TrackSession]s in parallel: [primaryTrack] captures
+ * [ScrcpyAudioSource.VOICE_CALL_UPLINK] (your side) and [secondaryTrack] captures [ScrcpyAudioSource.VOICE_CALL_DOWNLINK]
+ * (the other party's side), each writing to its own file, sharing a single wall-clock PTS origin so the two
+ * files stay perfectly in sync when merged externally (e.g. for transcription).
+ *
  * Call [startPipeline] to initialize and start the recording, and [release] to clean up resources when done.
  */
 class AudioRecordingEngine {
 
     /**
-     * Parses the raw byte stream that arrives from the shell process pipe.
-     *
-     * Calls the attached callbacks with parsed audio packets and stream metadata.
+     * Bundles all resources belonging to a single scrcpy capture -> output file pipeline, so
+     * [startPipeline] can run one (single-track) or two (dual-track) of these concurrently.
      */
-    var scrcpyClient: ScrcpyClient? = null
+    private class TrackSession(
+        val outputPfd: ParcelFileDescriptor,
+        val recordingUri: Uri,
+        val scrcpyAudioMuxer: ScrcpyAudioMuxer,
+        val audioReadPipePfd: ParcelFileDescriptor,
+        val audioPipeReadScope: CoroutineScope
+    ) {
+        var scrcpyClient: ScrcpyClient? = null
 
-    /** Writes scrcpy decoded audio packets into the output container (OPUS/AAC). */
-    var scrcpyAudioMuxer: ScrcpyAudioMuxer? = null
+        /**
+         * Active codec enum resolved from the user's preference and confirmed by the stream header.
+         * Updated once [ScrcpyClient.AudioPacketListener.onMetadataReceived] fires.
+         * Defaults to [ScrcpyAudioCodec.OPUS] as a safe initial value before the stream header is read.
+         */
+        var currentCodecEnum: ScrcpyAudioCodec = ScrcpyAudioCodec.OPUS
+
+        /** The active pipe reading job, kept so [release] can wait to finish reading any late bytes. */
+        var audioPipeReadJob: Job? = null
+    }
+
+    /** The uplink track (or the sole track, when dual-track recording is off) of the current session. */
+    private var primaryTrack: TrackSession? = null
+
+    /** The downlink track of the current session. Null unless dual-track recording is enabled. */
+    private var secondaryTrack: TrackSession? = null
 
     /** Metadata captured during the [startPipeline] and locked. Used for checks in [release]. */
     var initializationMetadata: EnrichedCallData? = null
@@ -64,44 +90,16 @@ class AudioRecordingEngine {
         }
 
     /**
-     * Read end of the kernel pipe owned by the shell process.
-     * The shell process writes scrcpy-server audio bytes into the write end; this service
-     * reads from the read end. Android's [ParcelFileDescriptor] wraps a native file descriptor
-     * so it can be transferred across processes via Binder.
+     * URI of the primary (uplink, or sole) recording file.
+     * Used to delete the file if recording fails to start mid-initialization, and by callers to
+     * offer post-recording file actions.
      */
-    var audioReadPipePfd: ParcelFileDescriptor? = null
+    val currentRecordingUri: Uri?
+        get() = primaryTrack?.recordingUri
 
-    /**
-     * Write-access file descriptor for the output file.
-     * This is kept open for the duration of the recording so [ScrcpyAudioMuxer] can write to it,
-     * and is closed in [release] after the muxer finalizes the container header.
-     */
-    var outputPfd: ParcelFileDescriptor? = null
-
-    /**
-     * URI of the current recording file.
-     * Used to delete the file if recording fails to start mid-initialization.
-     */
-    var currentRecordingUri: Uri? = null
-
-    /**
-     * Active codec enum resolved from the user's preference and confirmed by the stream header.
-     * Updated once [ScrcpyClient.AudioPacketListener.onMetadataReceived] fires.
-     * Defaults to [ScrcpyAudioCodec.OPUS] as a safe initial value before the stream header is read.
-     */
-    var currentCodecEnum: ScrcpyAudioCodec = ScrcpyAudioCodec.OPUS
-
-    /**
-     * Coroutine scope for reading from the audio pipe data returned by the shell service.
-     * Initialised in [startPipeline] and cancelled in [release].
-     */
-    var audioPipeReadScope: CoroutineScope? = null
-
-    /**
-     * The active pipe reading job.
-     * We keep a reference so we can wait to finish reading any late bytes during [release].
-     */
-    var audioPipeReadJob: Job? = null
+    /** True while the primary track's audio-pipe read coroutine is still active (capturing audio). */
+    val isActivelyCapturingAudio: Boolean
+        get() = primaryTrack?.audioPipeReadJob?.isActive == true
 
     /** Whether the recording is currently paused by the user. */
     @Volatile
@@ -109,6 +107,8 @@ class AudioRecordingEngine {
 
     /**
      * Orchestrates the initialization and connection of the entire recording pipeline.
+     * Starts one [TrackSession] normally, or two (uplink + downlink) when
+     * [AppPreferences.isDualTrackRecordingEnabled] is on.
      * @throws PipelineInitializationException if any step of the initialization fails, with details for user-friendly and technical error reporting.
      */
     fun startPipeline(context: Service, service: IShellService, metadata: EnrichedCallData) {
@@ -125,22 +125,7 @@ class AudioRecordingEngine {
 
         val codecEnum = ScrcpyAudioCodec.fromKey(preferences.getAudioCodec())
         val bitRate = preferences.getAudioBitRate().takeIf { it > 0 } ?: codecEnum.defaultBitRate
-        val audioSourceEnum = ScrcpyAudioSource.fromKey(preferences.getAudioSource())
-
-        AppLogger.i( "Starting recording pipeline: source=${audioSourceEnum.cliKey} codec=${codecEnum.cliKey} bitrate=$bitRate")
-
-        val fileName = RecordingFileNameFormatter.formatFileName(context, metadata, codecEnum)
-
-        val safResult = SafHelper.createAudioFile(context, folderUri, fileName, codecEnum.mimeType)
-            ?: throw PipelineInitializationException(
-                userFriendlyMessage = context.getString(R.string.recording_error_file_creation),
-                technicalLogMessage = "Failed to create audio file in SAF storage"
-            )
-
-        AppLogger.d( "Created SAF recording file: ${safResult.uri}")
-
-        currentRecordingUri = safResult.uri
-        outputPfd = safResult.descriptor
+        val isDebuggingModeEnabled = preferences.isDebugEnabled()
 
         val serverPath = ScrcpyConfig.getServerPath(context)
         if (!ServerExtractor.ensureServerFile(context, serverPath)) {
@@ -150,17 +135,118 @@ class AudioRecordingEngine {
             )
         }
 
-        scrcpyAudioMuxer = ScrcpyAudioMuxer(outputPfd!!.fileDescriptor, safResult.displayName)
+        // Shared wall-clock origin so dual-track files' PTS=0 lines up to the exact same instant.
+        val sharedOriginNanos = System.nanoTime()
 
-        try {
-            audioReadPipePfd = service.startRecording(
-                audioSourceEnum.cliKey,
-                codecEnum.cliKey,
-                bitRate,
-                serverPath,
-                preferences.isDebugEnabled()
+        if (preferences.isDualTrackRecordingEnabled()) {
+            AppLogger.i( "Starting dual-track recording pipeline: codec=${codecEnum.cliKey} bitrate=$bitRate")
+
+            // If the downlink track below throws, primaryTrack stays set on this engine and will be
+            // torn down (and its file deleted) by the caller's cancel()/release() fallback - no
+            // manual rollback needed here.
+            primaryTrack = startTrack(
+                context = context,
+                service = service,
+                metadata = metadata,
+                folderUri = folderUri,
+                codecEnum = codecEnum,
+                bitRate = bitRate,
+                serverPath = serverPath,
+                isDebuggingModeEnabled = isDebuggingModeEnabled,
+                audioSource = ScrcpyAudioSource.VOICE_CALL_UPLINK,
+                trackSuffix = "uplink",
+                sharedOriginNanos = sharedOriginNanos,
+                useSecondarySlot = false
             )
+            secondaryTrack = startTrack(
+                context = context,
+                service = service,
+                metadata = metadata,
+                folderUri = folderUri,
+                codecEnum = codecEnum,
+                bitRate = bitRate,
+                serverPath = serverPath,
+                isDebuggingModeEnabled = isDebuggingModeEnabled,
+                audioSource = ScrcpyAudioSource.VOICE_CALL_DOWNLINK,
+                trackSuffix = "downlink",
+                sharedOriginNanos = sharedOriginNanos,
+                useSecondarySlot = true
+            )
+        } else {
+            val audioSourceEnum = ScrcpyAudioSource.fromKey(preferences.getAudioSource())
+            AppLogger.i( "Starting recording pipeline: source=${audioSourceEnum.cliKey} codec=${codecEnum.cliKey} bitrate=$bitRate")
+
+            primaryTrack = startTrack(
+                context = context,
+                service = service,
+                metadata = metadata,
+                folderUri = folderUri,
+                codecEnum = codecEnum,
+                bitRate = bitRate,
+                serverPath = serverPath,
+                isDebuggingModeEnabled = isDebuggingModeEnabled,
+                audioSource = audioSourceEnum,
+                trackSuffix = null,
+                sharedOriginNanos = sharedOriginNanos,
+                useSecondarySlot = false
+            )
+        }
+    }
+
+    /**
+     * Creates the output file, muxer, shell-side capture, and [ScrcpyClient] for a single track,
+     * and starts its pipe-reading coroutine.
+     *
+     * @param useSecondarySlot When true, uses [IShellService.startSecondaryRecording] instead of
+     *                         [IShellService.startRecording] so this track runs in its own
+     *                         concurrent shell-side scrcpy-server process (used for the downlink
+     *                         track in dual-track mode).
+     * @throws PipelineInitializationException on any failure; cleans up its own partial file/pipe/output
+     *         before throwing so a failure here never leaks resources for *this* track.
+     */
+    private fun startTrack(
+        context: Service,
+        service: IShellService,
+        metadata: EnrichedCallData,
+        folderUri: Uri,
+        codecEnum: ScrcpyAudioCodec,
+        bitRate: Int,
+        serverPath: String,
+        isDebuggingModeEnabled: Boolean,
+        audioSource: ScrcpyAudioSource,
+        trackSuffix: String?,
+        sharedOriginNanos: Long,
+        useSecondarySlot: Boolean
+    ): TrackSession {
+        val fileName = RecordingFileNameFormatter.formatFileName(context, metadata, codecEnum, trackSuffix = trackSuffix)
+
+        val safResult = SafHelper.createAudioFile(context, folderUri, fileName, codecEnum.mimeType)
+            ?: throw PipelineInitializationException(
+                userFriendlyMessage = context.getString(R.string.recording_error_file_creation),
+                technicalLogMessage = "Failed to create audio file in SAF storage"
+            )
+
+        AppLogger.d( "Created SAF recording file: ${safResult.uri}")
+
+        val outputPfd = safResult.descriptor
+        val scrcpyAudioMuxer = ScrcpyAudioMuxer(outputPfd.fileDescriptor, safResult.displayName, sharedOriginNanos)
+
+        val audioReadPipePfd = try {
+            (if (useSecondarySlot) {
+                service.startSecondaryRecording(audioSource.cliKey, codecEnum.cliKey, bitRate, serverPath, isDebuggingModeEnabled)
+            } else {
+                service.startRecording(audioSource.cliKey, codecEnum.cliKey, bitRate, serverPath, isDebuggingModeEnabled)
+            }) ?: throw PipelineInitializationException(
+                userFriendlyMessage = context.getString(R.string.recording_error_start_failed),
+                technicalLogMessage = "Shell service returned null pipe – cannot start recording"
+            )
+        } catch (e: PipelineInitializationException) {
+            runCatching { outputPfd.close() }
+            runCatching { DocumentFile.fromSingleUri(context, safResult.uri)?.delete() }
+            throw e
         } catch (e: Exception) {
+            runCatching { outputPfd.close() }
+            runCatching { DocumentFile.fromSingleUri(context, safResult.uri)?.delete() }
             throw PipelineInitializationException(
                 userFriendlyMessage = e.localizedMessage ?: context.getString(R.string.recording_error_start_failed),
                 technicalLogMessage = "Remote exception calling startRecording",
@@ -168,60 +254,82 @@ class AudioRecordingEngine {
             )
         }
 
-        val inputPfd = audioReadPipePfd ?: throw PipelineInitializationException(
-            userFriendlyMessage = context.getString(R.string.recording_error_start_failed),
-            technicalLogMessage = "Shell service returned null pipe – cannot start recording"
+        val track = TrackSession(
+            outputPfd = outputPfd,
+            recordingUri = safResult.uri,
+            scrcpyAudioMuxer = scrcpyAudioMuxer,
+            audioReadPipePfd = audioReadPipePfd,
+            audioPipeReadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         )
 
-        currentCodecEnum = codecEnum
-        scrcpyAudioMuxer?.initialize(currentCodecEnum)
+        track.currentCodecEnum = codecEnum
+        track.scrcpyAudioMuxer.initialize(track.currentCodecEnum)
 
-        scrcpyClient = ScrcpyClient(
-            inputPfd = inputPfd,
+        track.scrcpyClient = ScrcpyClient(
+            inputPfd = audioReadPipePfd,
             expectedCodec = codecEnum,
-            listener = object : ScrcpyClient.AudioPacketListener {
-                /**
-                 * Called once after the 4-byte codec FourCC is verified from the stream header.
-                 * We re-initialise the muxer with the confirmed codec in case it differs from our initial assumption.
-                 */
-                override fun onMetadataReceived(codec: ScrcpyAudioCodec) {
-                    AppLogger.d( "Stream metadata confirmed: codec=${codec.cliKey} fourCC=0x${codec.codecFourCC.toString(16)}")
-                    currentCodecEnum = codec
-                    scrcpyAudioMuxer?.initialize(codec)
-                }
-
-                /** Called for every audio frame received from the pipe. */
-                override fun onAudioPacket(packet: ScrcpyClient.AudioPacket) {
-                    if (isPaused) return // Drop packets while paused, do not write to muxer
-                    scrcpyAudioMuxer?.writePacket(packet, currentCodecEnum)
-                }
-
-                /** Called when the stream ends normally (EOF) or with an error. */
-                override fun onStreamEnd(error: String?) {
-                    if (error != null) {
-                        AppLogger.w( "Scrcpy-client reported stopping parsing due to an audio stream error: $error")
-                    } else {
-                        AppLogger.d( "Scrcpy-client reported our pipe read stream ended normally (EOF)")
-                    }
-                }
-            }
+            listener = buildPacketListener(track)
         )
 
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-        audioPipeReadScope = scope
-        audioPipeReadJob = scope.launch(Dispatchers.IO) {
+        track.audioPipeReadJob = track.audioPipeReadScope.launch(Dispatchers.IO) {
             try {
-                scrcpyClient?.start()
+                track.scrcpyClient?.start()
             } catch (e: Exception) {
                 AppLogger.w( "Audio reader ended: ${e.message}")
+            }
+        }
+
+        return track
+    }
+
+    /**
+     * Builds the [ScrcpyClient.AudioPacketListener] that wires a track's parsed packets into its
+     * own [ScrcpyAudioMuxer], respecting [isPaused].
+     */
+    private fun buildPacketListener(track: TrackSession): ScrcpyClient.AudioPacketListener {
+        return object : ScrcpyClient.AudioPacketListener {
+            /**
+             * Called once after the 4-byte codec FourCC is verified from the stream header.
+             * We re-initialise the muxer with the confirmed codec in case it differs from our initial assumption.
+             */
+            override fun onMetadataReceived(codec: ScrcpyAudioCodec) {
+                AppLogger.d( "Stream metadata confirmed: codec=${codec.cliKey} fourCC=0x${codec.codecFourCC.toString(16)}")
+                track.currentCodecEnum = codec
+                track.scrcpyAudioMuxer.initialize(codec)
+            }
+
+            /** Called for every audio frame received from the pipe. */
+            override fun onAudioPacket(packet: ScrcpyClient.AudioPacket) {
+                if (isPaused) return // Drop packets while paused, do not write to muxer
+                track.scrcpyAudioMuxer.writePacket(packet, track.currentCodecEnum)
+            }
+
+            /** Called when the stream ends normally (EOF) or with an error. */
+            override fun onStreamEnd(error: String?) {
+                if (error != null) {
+                    AppLogger.w( "Scrcpy-client reported stopping parsing due to an audio stream error: $error")
+                } else {
+                    AppLogger.d( "Scrcpy-client reported our pipe read stream ended normally (EOF)")
+                }
             }
         }
     }
 
     /**
-     * Safely releases all held resources in the correct order.
+     * Safely releases all held resources in the correct order, for both tracks if dual-track
+     * recording was active.
      * Everything is wrapped in runCatching to ignore any exceptions and continue the cleanup.
-     *
+     */
+    fun release(shellService: IShellService?) {
+        AppLogger.i( "Releasing session resources and recording pipeline...")
+        releaseTrack(primaryTrack, shellService, isSecondary = false)
+        releaseTrack(secondaryTrack, shellService, isSecondary = true)
+        primaryTrack = null
+        secondaryTrack = null
+    }
+
+    /**
+     * Tears down a single [TrackSession] in the correct order:
      * 1. Stops the remote shell service process natively, which gives scrcpy-server a grace period
      *    to write its final audio bytes before closing the pipe from the sender side.
      * 2. Waits for the local reading coroutine to reach EOF and finish parsing the late bytes.
@@ -229,38 +337,42 @@ class AudioRecordingEngine {
      * 4. Closes the inbound pipe.
      * 5. Closes the muxer and output file descriptor to finalize the container header.
      */
-    fun release(shellService: IShellService?) {
-        AppLogger.i( "Releasing session resources and recording pipeline...")
-        runCatching { shellService?.stopRecording() }
+    private fun releaseTrack(track: TrackSession?, shellService: IShellService?, isSecondary: Boolean) {
+        if (track == null) return
+
+        runCatching {
+            if (isSecondary) shellService?.stopSecondaryRecording() else shellService?.stopRecording()
+        }
 
         runCatching {
             runBlocking {
                 withTimeoutOrNull(2000L) {
-                    audioPipeReadJob?.join()
+                    track.audioPipeReadJob?.join()
                 }
             }
         }
 
-        runCatching { scrcpyClient?.stop() }
-        runCatching { audioPipeReadScope?.cancel() }
-        runCatching { audioReadPipePfd?.close() }
-        runCatching { scrcpyAudioMuxer?.close() }
-        runCatching { outputPfd?.close() }
+        runCatching { track.scrcpyClient?.stop() }
+        runCatching { track.audioPipeReadScope.cancel() }
+        runCatching { track.audioReadPipePfd.close() }
+        runCatching { track.scrcpyAudioMuxer.close() }
+        runCatching { track.outputPfd.close() }
     }
 
     /**
-     * Trigger the normal [release] flow, then followed by an attempt to delete the incomplete recording file if it was created
-     * during the pipeline initialization.
+     * Trigger the normal [release] flow, then followed by an attempt to delete the incomplete recording file(s)
+     * created during the pipeline initialization (both tracks', when dual-track recording was active).
      */
     fun cancel(context: Context, shellService: IShellService?) {
+        val urisToDelete = listOfNotNull(primaryTrack?.recordingUri, secondaryTrack?.recordingUri)
         release(shellService)
-        try {
-            currentRecordingUri?.let { uri ->
+        urisToDelete.forEach { uri ->
+            try {
                 DocumentFile.fromSingleUri(context, uri)?.delete()
+                AppLogger.d( "Cleaned up empty file after start failure")
+            } catch (e: Exception) {
+                AppLogger.w( "Failed to cleanup empty file", e)
             }
-            AppLogger.d( "Cleaned up empty file after start failure")
-        } catch (e: Exception) {
-            AppLogger.w( "Failed to cleanup empty file", e)
         }
     }
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingForegroundService.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingForegroundService.kt
@@ -112,7 +112,7 @@ class RecordingForegroundService : Service() {
 
     /** True only if the pipeline is actively reading and capturing audio. */
     private val isCurrentlyRecording: Boolean
-        get() = (currentState as? RecordingServiceState.Active)?.engine?.audioPipeReadJob?.isActive == true
+        get() = (currentState as? RecordingServiceState.Active)?.engine?.isActivelyCapturingAudio == true
 
     // ── Service lifecycle ──────────────────────────────────────────────────────────────
 

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/shell/ShellService.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/shell/ShellService.kt
@@ -29,6 +29,8 @@ import kotlin.system.exitProcess
 class ShellService : IShellService.Stub {
 
     private val audioPipeline by lazy { ShellAudioPipeline() }
+    /** Second, independent pipeline instance used for dual-track (uplink+downlink) recording. */
+    private val secondaryAudioPipeline by lazy { ShellAudioPipeline() }
     private val commandExecutor by lazy { ShellCommandExecutor() }
 
     // ---- Shizuku-required constructors
@@ -72,6 +74,20 @@ class ShellService : IShellService.Stub {
         audioPipeline.stopCapture()
     }
 
+    override fun startSecondaryRecording(
+        audioSource: String,
+        audioCodec: String,
+        audioBitRate: Int,
+        serverPath: String,
+        isDebuggingModeEnabled: Boolean
+    ): ParcelFileDescriptor? {
+        return secondaryAudioPipeline.startCapture(audioSource, audioCodec, audioBitRate, serverPath, isDebuggingModeEnabled)
+    }
+
+    override fun stopSecondaryRecording() {
+        secondaryAudioPipeline.stopCapture()
+    }
+
     override fun grantAppOpByPackage(packageName: String, opName: String, userProfileId: Int): Boolean {
         return commandExecutor.grantAppOpByPackage(packageName, opName, userProfileId)
     }
@@ -92,6 +108,7 @@ class ShellService : IShellService.Stub {
     override fun destroy() {
         AppLogger.i("ShellService.destroy() – terminating shell process")
         stopRecording()
+        stopSecondaryRecording()
         exitProcess(0)
     }
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
@@ -755,35 +755,55 @@ private fun AudioSection(preferences: AppPreferences, updateTrigger: Int, action
     val audioSource = remember(updateTrigger) { preferences.getAudioSource() }
     val audioCodec = remember(updateTrigger) { preferences.getAudioCodec() }
     val savedBitRate = remember(updateTrigger) { preferences.getAudioBitRate() }
-        
+    val dualTrackRecording = remember(updateTrigger) { preferences.isDualTrackRecordingEnabled() }
+
     SettingsSection(title = stringResource(R.string.settings_section_audio)) {
         val currentSdk = Build.VERSION.SDK_INT
 
-        // Build the source list from the enum, hiding debug-only entries when debug is off.
-        // Items that require an API level not available on this device are shown as disabled.
-        val audioSourceOptions = ScrcpyAudioSource.entries
-            .filter { !it.isDebugOnly || isDebugEnabled }
-            .map { source ->
-                OptionItem(
-                    key         = source.cliKey,
-                    label       = stringResource(source.titleResId),
-                    description = stringResource(source.descriptionResId),
-                    // Enabled only when the current SDK is within the source's API range.
-                    enabled     = currentSdk >= source.minApi &&
-                                  (source.maxApi == null || currentSdk <= source.maxApi)
-                )
-            }
-
-        val selectedAudio = audioSourceOptions.find { it.key == audioSource }
-            ?: audioSourceOptions.first()
-
-        M3DropdownField(
-            label    = stringResource(R.string.settings_audio_source),
-            selected = selectedAudio,
-            options  = audioSourceOptions,
-            onOptionSelected = { actions.setAudioSource(it.key) },
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+        ToggleListItem(
+            label           = stringResource(R.string.settings_dual_track_recording),
+            description     = stringResource(R.string.settings_dual_track_recording_description),
+            checked         = dualTrackRecording,
+            onCheckedChange = { actions.setDualTrackRecordingEnabled(it) },
+            modifier        = Modifier.padding(horizontal = 16.dp)
         )
+
+        // The audio source picker is meaningless in dual-track mode (uplink/downlink are forced),
+        // so it's hidden entirely instead of shown disabled.
+        if (!dualTrackRecording) {
+            // Build the source list from the enum, hiding debug-only entries when debug is off.
+            // Items that require an API level not available on this device are shown as disabled.
+            val audioSourceOptions = ScrcpyAudioSource.entries
+                .filter { !it.isDebugOnly || isDebugEnabled }
+                .map { source ->
+                    OptionItem(
+                        key         = source.cliKey,
+                        label       = stringResource(source.titleResId),
+                        description = stringResource(source.descriptionResId),
+                        // Enabled only when the current SDK is within the source's API range.
+                        enabled     = currentSdk >= source.minApi &&
+                                      (source.maxApi == null || currentSdk <= source.maxApi)
+                    )
+                }
+
+            val selectedAudio = audioSourceOptions.find { it.key == audioSource }
+                ?: audioSourceOptions.first()
+
+            M3DropdownField(
+                label    = stringResource(R.string.settings_audio_source),
+                selected = selectedAudio,
+                options  = audioSourceOptions,
+                onOptionSelected = { actions.setAudioSource(it.key) },
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+            )
+        } else {
+            Text(
+                text     = stringResource(R.string.settings_dual_track_recording_source_note),
+                style    = MaterialTheme.typography.labelSmall,
+                color    = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp)
+            )
+        }
 
         val codecOptions = ScrcpyAudioCodec.entries
             .map { OptionItem(it.cliKey, stringResource(it.titleResId)) }
@@ -1183,6 +1203,7 @@ private fun SettingsScreenPreview() {
             override fun setAudioSource(source: String) {}
             override fun setAudioCodec(codec: String) {}
             override fun setAudioBitRate(bitRate: Int) {}
+            override fun setDualTrackRecordingEnabled(enabled: Boolean) {}
             override fun setThemeMode(mode: AppPreferences.ThemeMode) {}
             override fun setDynamicColorEnabled(enabled: Boolean) {}
             override fun setShowToastsEnabled(enabled: Boolean) {}

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/viewmodels/SettingsViewModel.kt
@@ -59,6 +59,7 @@ interface SettingsActions {
     fun setAudioSource(source: String)
     fun setAudioCodec(codec: String)
     fun setAudioBitRate(bitRate: Int)
+    fun setDualTrackRecordingEnabled(enabled: Boolean)
     fun setThemeMode(mode: AppPreferences.ThemeMode)
     fun setDynamicColorEnabled(enabled: Boolean)
     fun setShowToastsEnabled(enabled: Boolean)
@@ -250,6 +251,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
      */
     override fun setAudioBitRate(bitRate: Int) {
         preferences.setAudioBitRate(bitRate)
+        refresh()
+    }
+
+    /** Enables or disables dual-track recording (separate uplink/downlink files). */
+    override fun setDualTrackRecordingEnabled(enabled: Boolean) {
+        preferences.setDualTrackRecordingEnabled(enabled)
         refresh()
     }
 

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/utils/RecordingFileNameFormatter.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/utils/RecordingFileNameFormatter.kt
@@ -52,13 +52,16 @@ object RecordingFileNameFormatter {
      * @param metadata Defines the main properties (direction, phone number, cross country).
      * @param codec The selected ScrcpyAudioCodec used to determine the file extension.
      * @param customFormat An optional custom format string to use instead of the one from preferences. Useful for testing or one-off formatting without changing user settings.
+     * @param trackSuffix An optional literal token appended before the extension (e.g. "uplink"), used
+     *                    to distinguish the two files produced by dual-track recording.
      * @return A filesystem-safe filename string.
      */
     fun formatFileName(
         context: Context,
         metadata: EnrichedCallData,
         codec: ScrcpyAudioCodec,
-        customFormat: String? = null
+        customFormat: String? = null,
+        trackSuffix: String? = null
     ): String {
         val template = customFormat ?: AppPreferences(context).getFileNameTemplate()
 
@@ -109,7 +112,8 @@ object RecordingFileNameFormatter {
             .replace(FileNamePlaceholder.PACKAGE_NAME.tag, packageName)
 
         AppLogger.v( "Formatted base filename: '$baseName' with template '$template'")
-        return "$baseName${codec.containerExtension}"
+        val suffix = trackSuffix?.let { "_$it" } ?: ""
+        return "$baseName$suffix${codec.containerExtension}"
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,6 +217,10 @@
     <string name="settings_audio_bitrate">Audio bit rate</string>
     <string name="audio_bitrate_kbps" translatable="false">%1$d kbps</string>
 
+    <string name="settings_dual_track_recording">Record each side separately</string>
+    <string name="settings_dual_track_recording_description">Saves two files per call, one for your side and one for the caller\'s side, always in sync. Useful for transcription with clear speaker separation.</string>
+    <string name="settings_dual_track_recording_source_note">Audio source is ignored while this is on; the uplink and downlink sources are used automatically.</string>
+
     <string name="settings_audio_source">Audio source</string>
     <string name="audio_source_voice_comm" translatable="false">Voice communication mic</string>
     <string name="audio_source_voice_comm_description">Microphone audio source tuned for voice communications. Built-in echo cancellation.</string>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,3 +79,13 @@ When this option is enabled, the application will behave as follows:
 
 >[!WARNING]
 > As mentioned earlier, recording may take a few seconds because Shizuku needs to start. If you enable **Start only when recording**, be aware that audio will **not start recording immediately** when you press the button.
+
+## Recording each side of the call separately
+In the **Audio configuration** section of Settings, enabling **Record each side separately** captures your side (uplink) and the other party's side (downlink) as two separate, time-synced files instead of one mixed recording. This is intended for transcription workflows where you want each speaker clearly attributed.
+
+While this is enabled, the **Audio source** dropdown is ignored (the uplink/downlink sources are used automatically), and two scrcpy-server processes run concurrently for the duration of the call.
+
+If a transcription tool you use requires a single stereo file with one speaker per channel instead of two files, you can combine the two outputs afterward with `ffmpeg`, without any quality loss:
+```
+ffmpeg -i call_..._uplink.opus -i call_..._downlink.opus -filter_complex amerge -ac 2 call_stereo.opus
+```


### PR DESCRIPTION
## Summary

Adds a **"Record each side separately"** toggle (Settings -> Audio configuration) that captures the uplink (your mic) and downlink (the other party) as two independent, time-synced files instead of one mixed recording, e.g. `call_..._uplink.opus` + `call_..._downlink.opus`.

- `ShellService` now runs a second, independent `ShellAudioPipeline` instance behind two new AIDL methods (`startSecondaryRecording`/`stopSecondaryRecording`), so a second `scrcpy-server` process (`voice-call-downlink`) runs concurrently alongside the existing one (`voice-call-uplink`), each with its own socket/pipe.
- `AudioRecordingEngine` was reworked around a private `TrackSession` bundle so it can drive one (normal) or two (dual-track) capture pipelines in parallel, with symmetric start/rollback/teardown for both.
- `ScrcpyAudioMuxer` accepts an optional shared wall-clock origin so both files' PTS=0 line up to the exact same instant, keeping the two tracks in sync for downstream processing.
- `RecordingFileNameFormatter` gained an optional filename suffix (`_uplink`/`_downlink`) to distinguish the two outputs.
- When the toggle is on, the Audio source dropdown is hidden (the uplink/downlink sources are forced) instead of shown disabled.

## Why this matters

Today, recording both sides of a call only produces one mixed file (`VOICE_CALL`), or a single-sided file (`VOICE_CALL_UPLINK`/`VOICE_CALL_DOWNLINK`) if you pick one manually — there's no way to get both sides at once without them being mixed together. For transcription workflows, a mixed track makes speaker attribution unreliable (diarization heuristics), whereas two separate, perfectly-synced mono files make "who said what" deterministic: it's just "which file". This mirrors how call-center transcription products (e.g. Twilio/Deepgram dual-channel) typically separate speakers.

Two files (rather than one file with two audio tracks) was chosen deliberately: Android's `MediaMuxer` only supports a single audio track per OGG container, so a true single-file two-track approach would only work for AAC/MP4, not Opus. Two mono files work identically for both codecs, need no new audio pipeline stage, and can still be losslessly combined into one stereo file afterward with a single `ffmpeg` command (documented in `docs/configuration.md`) if a specific transcription API requires that shape instead.

## Testing

- Verified end-to-end on a real device (Pixel 10 Pro, Android 16) via Shizuku: placed and received real calls with the toggle off (unchanged single-file behavior, confirmed byte-identical code path) and on (confirmed two files appear in the recording folder with `_uplink`/`_downlink` suffixes, both playable, both non-empty, both starting from the same wall-clock instant).
- Confirmed pause/resume and mid-call cancel/error paths correctly tear down both tracks with no orphaned `scrcpy-server` process and no partial/locked output file.
- Confirmed toggling the setting on/off correctly hides/reveals the Audio source dropdown.
- Full `./gradlew assembleDebug` build passes with no new warnings from the changed files.

This is additive and off by default; existing single-track recording behavior is unchanged when the toggle is off.