### PR TITLE
fix(CallDetectionMode): Use fully qualified role names for RoleGrant steps

### DIFF
--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/callDetection/CallDetectionMode.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/callDetection/CallDetectionMode.kt
@@ -79,8 +79,9 @@ enum class CallDetectionMode(
                     EscalationStep.UidAppOp(opString = "android:manage_ongoing_calls", minApi = 31, maxApi = Int.MAX_VALUE),
                     // Some chinese ROMs (like Vivo, Oppo, Xiaomi) have very aggressive permission management and system monitoring apps, we try more open fallbacks.
                     // See: https://github.com/kitsumed/ShizuCallRecorder/issues/41
-                    EscalationStep.RoleGrant(roleName = "COMPANION_DEVICE_GLASSES", minApi = 34, maxApi = Int.MAX_VALUE), // Prioritize glasses on Android 14+ as they have a little bit less permission...
-                    EscalationStep.RoleGrant(roleName = "COMPANION_DEVICE_WATCH", minApi = 31, maxApi = Int.MAX_VALUE),
+                    // Role names must be the fully qualified names declared in roles.xml, the role shell command passes them through verbatim.
+                    EscalationStep.RoleGrant(roleName = "android.app.role.COMPANION_DEVICE_GLASSES", minApi = 34, maxApi = Int.MAX_VALUE), // Prioritize glasses on Android 14+ as they have a little bit less permission...
+                    EscalationStep.RoleGrant(roleName = "android.app.role.COMPANION_DEVICE_WATCH", minApi = 31, maxApi = Int.MAX_VALUE),
                 )
             ),
         )

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/shell/ShellCommandExecutor.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/shell/ShellCommandExecutor.kt
@@ -46,7 +46,8 @@ class ShellCommandExecutor {
      * List of roles can be found here: https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/Permission/PermissionController/res/xml/roles.xml?q=roles.xml
      *
      * @param packageName The package name of the app to grant the role to.
-     * @param roleName The name of the role to grant (e.g., "DIALER").
+     * @param roleName The fully qualified name of the role to grant (e.g., "android.app.role.DIALER").
+     * The shell command passes this value verbatim to RoleManager, so a short name matches no role and always fails.
      * @param userProfileId The user ID for which to grant the role.
      * @return True if the command was successful, false otherwise.
      */

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/shell/ShellCommandExecutor.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/shell/ShellCommandExecutor.kt
@@ -46,8 +46,7 @@ class ShellCommandExecutor {
      * List of roles can be found here: https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/Permission/PermissionController/res/xml/roles.xml?q=roles.xml
      *
      * @param packageName The package name of the app to grant the role to.
-     * @param roleName The fully qualified name of the role to grant (e.g., "android.app.role.DIALER").
-     * The shell command passes this value verbatim to RoleManager, so a short name matches no role and always fails.
+     * @param roleName The fully qualified name of the role to grant (e.g., `android.app.role.DIALER`).
      * @param userProfileId The user ID for which to grant the role.
      * @return True if the command was successful, false otherwise.
      */


### PR DESCRIPTION
## Problem

Both `RoleGrant` escalation steps for `android:manage_ongoing_calls` use short role names:

```kotlin
EscalationStep.RoleGrant(roleName = "COMPANION_DEVICE_GLASSES", minApi = 34, ...)
EscalationStep.RoleGrant(roleName = "COMPANION_DEVICE_WATCH", minApi = 31, ...)
```

`ShellCommandExecutor.grantRole()` turns that into `cmd role add-role-holder --user 0 COMPANION_DEVICE_WATCH <package>`.

`RoleShellCommand.runAddRoleHolder()` reads the role name argument and passes it straight to `RoleManager.addRoleHolderAsUser()` without normalizing it:
https://android.googlesource.com/platform/packages/modules/Permission/+/refs/heads/main/service/java/com/android/role/RoleShellCommand.java

Roles are declared in `roles.xml` under fully qualified names, `android.app.role.COMPANION_DEVICE_WATCH` and `android.app.role.COMPANION_DEVICE_GLASSES`:
https://android.googlesource.com/platform/packages/modules/Permission/+/refs/heads/main/PermissionController/res/xml/roles.xml

The short names therefore match no role and both steps always fail.

This matters most on the ROMs these fallbacks were added for in #41. Those revert AppOps changes back to default, so with the two RoleGrant steps failing as well, the whole chain fails and the user gets "All escalation steps (4) were exhausted".

## Fix

Use the fully qualified role names.

Also corrected the `grantRole` KDoc: its example was `"DIALER"`, which has the same problem.

## Files changed

- `services/callDetection/CallDetectionMode.kt` - role names for the two `RoleGrant` steps
- `services/shell/ShellCommandExecutor.kt` - KDoc only, no behaviour change

## Verification

Vivo V2538 (OriginOS 6), Android 16 (API 36), app 1.2.0. The app reported all 4 escalation steps exhausted. This is the same ROM as the device in #41.

Running the corrected command through a Shizuku shell (`id` confirms `uid=2000(shell)`):

```
$ cmd role add-role-holder android.app.role.COMPANION_DEVICE_WATCH com.kitsumed.shizucallrecorder
$ cmd role get-role-holders android.app.role.COMPANION_DEVICE_WATCH
com.kitsumed.shizucallrecorder
$ appops get com.kitsumed.shizucallrecorder android:manage_ongoing_calls
Uid mode: MANAGE_ONGOING_CALLS: allow
```

The "Manage Ongoing Calls" onboarding step then cleared, and a subsequent call recorded successfully with `source=voice-call codec=opus`.

To be precise about what was tested: I verified the corrected shell command grants the permission on the affected device. I have not built and installed a patched APK, so the escalation chain itself has not been exercised end to end.

Relates to #41.

## AI disclosure (rule 7)

I used Claude (Opus 5) as a tool to read the AOSP sources, identify the mismatch, and draft this description. I ran the on-device verification myself and reviewed the change before submitting. The commit carries `Assisted-by: Claude Opus 5` rather than a `Co-authored-by:` tag.
