### PR TITLE
Improve recording deletion and post-call details

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -274,4 +274,6 @@ dependencies {
     // Shizuku
     implementation(libs.shizukuApi)
     implementation(libs.shizukuProvider)
+
+    testImplementation(libs.junit)
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/data/AppPreferences.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/data/AppPreferences.kt
@@ -47,6 +47,7 @@ class AppPreferences(context: Context) {
         const val RECORD_THIRD_PARTY_CALLS = false
 
         const val POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED = false
+        const val SHOW_DELETE_CONFIRMATION = true
         const val AUTO_RECORD_INCOMING = false
         const val AUTO_RECORD_OUTGOING = false
 
@@ -101,6 +102,7 @@ class AppPreferences(context: Context) {
         RECORDING_FOLDER_URI("recording_folder_uri"),
         VIBRATION_ENABLED("vibration_enabled"),
         POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED ("post_recording_file_actions_notification_enabled"),
+        SHOW_DELETE_CONFIRMATION("show_delete_confirmation"),
         AUTO_RECORD_INCOMING("auto_record_incoming"),
         AUTO_RECORD_OUTGOING("auto_record_outgoing"),
         IGNORE_ANONYMOUS_INCOMING("ignore_anonymous_incoming"),
@@ -244,6 +246,12 @@ class AppPreferences(context: Context) {
     fun isPostRecordingFileActionsNotificationEnabled() = getBoolean(Key.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED, DefaultsValue.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED)
     /** Sets whether post-recording file actions notification is enabled. */
     fun setPostRecordingFileActionsNotificationEnabled(enabled: Boolean) = setBoolean(Key.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED, enabled)
+
+    /** Checks if deleting a recording requires confirmation. */
+    fun isShowDeleteConfirmationEnabled() = getBoolean(Key.SHOW_DELETE_CONFIRMATION, DefaultsValue.SHOW_DELETE_CONFIRMATION)
+
+    /** Sets whether deleting a recording requires confirmation. */
+    fun setShowDeleteConfirmationEnabled(enabled: Boolean) = setBoolean(Key.SHOW_DELETE_CONFIRMATION, enabled)
 
     /**
      * Gets the current preferred detection mode, automatically falling back

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/callDetection/incall/InCallService.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/callDetection/incall/InCallService.kt
@@ -170,7 +170,7 @@ class InCallService : InCallService() {
             val packageName = details.accountHandle.componentName.packageName
 
             val rawCallData = RawCallData(
-                rawPhoneNumber = PhoneNumberManager.normalisePhoneNumber(rawNumber),
+                rawPhoneNumber = normaliseCallHandleNumber(rawNumber, packageName),
                 direction = direction,
                 osProvidedCallerName = oscallerName,
                 packageName = packageName
@@ -193,4 +193,10 @@ class InCallService : InCallService() {
             }
         }
     }
+}
+
+internal fun normaliseCallHandleNumber(rawNumber: String, packageName: String): String {
+    val number = PhoneNumberManager.normalisePhoneNumber(rawNumber)
+    val isWhatsApp = packageName == "com.whatsapp" || packageName == "com.whatsapp.w4b"
+    return if (isWhatsApp && number.isNotEmpty() && !number.startsWith("+")) "+$number" else number
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/DeleteDialogConfirmationActivity.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/DeleteDialogConfirmationActivity.kt
@@ -17,10 +17,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
 import androidx.documentfile.provider.DocumentFile
 import com.kitsumed.shizucallrecorder.R
+import com.kitsumed.shizucallrecorder.data.AppPreferences
 import com.kitsumed.shizucallrecorder.utils.AppLogger
 
 /**
- * This is a simple activity that shows a confirmation dialog to the user before deleting a recording file.
+ * Deletes a recording file, optionally showing a confirmation dialog first.
  */
 class DeleteDialogConfirmationActivity : AppCompatActivity() {
 
@@ -34,22 +35,17 @@ class DeleteDialogConfirmationActivity : AppCompatActivity() {
             return
         }
 
+        if (!shouldShowDeleteConfirmation(AppPreferences(this).isShowDeleteConfirmationEnabled())) {
+            deleteRecording(fileUri)
+            finish()
+            return
+        }
+
         AlertDialog.Builder(this)
             .setTitle(getString(R.string.delete_recording_confirmation_title))
             .setMessage(getString(R.string.delete_recording_confirmation_message))
             .setPositiveButton(getString(R.string.general_delete)) { dialog, _ ->
-                try {
-                    val deleted = DocumentFile.fromSingleUri(this, fileUri)?.delete() == true
-                    if (deleted) {
-                        Toast.makeText(this, getString(R.string.general_deleted), Toast.LENGTH_SHORT).show()
-                        // Remove the notifications from the notification tray since file no longer exists
-                        val manager = getSystemService(android.app.NotificationManager::class.java)
-                        manager.cancel(RecordingNotificationHelper.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ID)
-                    }
-                } catch (e: Exception) {
-                    AppLogger.e( "Failed to delete file: $fileUri", e)
-                    Toast.makeText(this, getString(R.string.delete_recording_confirmation_failed), Toast.LENGTH_LONG).show()
-                }
+                deleteRecording(fileUri)
                 dialog.dismiss()
             }
             .setNegativeButton(getString(R.string.general_cancel)) { dialog, _ ->
@@ -59,4 +55,20 @@ class DeleteDialogConfirmationActivity : AppCompatActivity() {
                 finish()
             }.show()
     }
+
+    private fun deleteRecording(fileUri: Uri) {
+        try {
+            val deleted = DocumentFile.fromSingleUri(this, fileUri)?.delete() == true
+            if (deleted) {
+                Toast.makeText(this, getString(R.string.general_deleted), Toast.LENGTH_SHORT).show()
+                getSystemService(android.app.NotificationManager::class.java)
+                    .cancel(RecordingNotificationHelper.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ID)
+            }
+        } catch (e: Exception) {
+            AppLogger.e("Failed to delete file: $fileUri", e)
+            Toast.makeText(this, getString(R.string.delete_recording_confirmation_failed), Toast.LENGTH_LONG).show()
+        }
+    }
 }
+
+internal fun shouldShowDeleteConfirmation(enabled: Boolean) = enabled

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingNotificationHelper.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingNotificationHelper.kt
@@ -29,6 +29,7 @@ import androidx.core.app.NotificationCompat
 import com.kitsumed.shizucallrecorder.R
 import com.kitsumed.shizucallrecorder.data.AppPreferences
 import com.kitsumed.shizucallrecorder.data.call.EnrichedCallData
+import com.kitsumed.shizucallrecorder.utils.RecordingFileNameFormatter
 import com.kitsumed.shizucallrecorder.ui.theme.Green40
 
 class RecordingNotificationHelper(private val context: Context) {
@@ -264,7 +265,13 @@ class RecordingNotificationHelper(private val context: Context) {
             .setSmallIcon(R.drawable.ic_audio_file)
             .setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
             .setContentTitle(context.getString(R.string.post_recording_notification_title))
-            .setContentText(callMetadata.getBestNumber().takeIf { it.isNotEmpty() } ?: context.getString(R.string.post_recording_notification_unknown_caller))
+            .setContentText(
+                getPostRecordingCallerText(
+                    callMetadata,
+                    AppPreferences(context).getFileNameTemplate(),
+                    context.getString(R.string.post_recording_notification_unknown_caller)
+                )
+            )
             .setAutoCancel(true)
             .addAction(android.R.drawable.ic_media_play, context.getString(R.string.general_play), playPendingIntent)
             .addAction(android.R.drawable.ic_menu_share, context.getString(R.string.general_share), sharePendingIntent)
@@ -322,5 +329,18 @@ class RecordingNotificationHelper(private val context: Context) {
                 vibrator.vibrate(effect)
             }
         }
+    }
+}
+
+internal fun getPostRecordingCallerText(metadata: EnrichedCallData, fileNameTemplate: String, unknownCaller: String): String {
+    val number = metadata.getBestNumber()
+    val name = metadata.callerName?.takeIf {
+        it.isNotBlank() && fileNameTemplate.contains(RecordingFileNameFormatter.FileNamePlaceholder.CALLER_NAME.tag)
+    }
+
+    return when {
+        name != null && number.isNotEmpty() -> "$name ($number)"
+        name != null -> name
+        else -> number.ifEmpty { unknownCaller }
     }
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
@@ -543,6 +543,7 @@ private fun RecordingSection(
     val recordThirdPartyCalls = remember(updateTrigger) { preferences.isRecordThirdPartyCallsEnabled() }
     val fileNameFormat = remember(updateTrigger) { preferences.getFileNameTemplate() }
     val postRecordingFileNotifications = remember(updateTrigger) { preferences.isPostRecordingFileActionsNotificationEnabled() }
+    val showDeleteConfirmation = remember(updateTrigger) { preferences.isShowDeleteConfirmationEnabled() }
     val isVibrationEnabled = remember(updateTrigger) { preferences.isVibrationEnabled() }
     val autoRecordIncoming = remember(updateTrigger) { preferences.isAutoRecordIncomingEnabled() }
     val autoRecordOutgoing = remember(updateTrigger) { preferences.isAutoRecordOutgoingEnabled() }
@@ -652,6 +653,12 @@ private fun RecordingSection(
             description = stringResource(R.string.settings_post_recording_notification_description),
             checked = postRecordingFileNotifications,
             onCheckedChange = { actions.setPostRecordingFileNotification(it) }
+        )
+
+        ToggleListItem(
+            label = stringResource(R.string.settings_show_delete_confirmation),
+            checked = showDeleteConfirmation,
+            onCheckedChange = { actions.setShowDeleteConfirmation(it) }
         )
 
         ToggleListItem(
@@ -1222,6 +1229,7 @@ private fun SettingsScreenPreview() {
             override fun setCallDetectionMode(mode: CallDetectionMode) {}
             override fun setRecordThirdPartyCalls(enabled: Boolean) {}
             override fun setPostRecordingFileNotification(enabled: Boolean) {}
+            override fun setShowDeleteConfirmation(enabled: Boolean) {}
             override fun setOverlayEnabled(enabled: Boolean) {}
         }
 

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/viewmodels/SettingsViewModel.kt
@@ -77,6 +77,7 @@ interface SettingsActions {
     fun setCallDetectionMode(mode: CallDetectionMode)
     fun setRecordThirdPartyCalls(enabled: Boolean)
     fun setPostRecordingFileNotification(enabled: Boolean)
+    fun setShowDeleteConfirmation(enabled: Boolean)
     fun setOverlayEnabled(enabled: Boolean)
 }
 
@@ -422,6 +423,11 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
      */
     override fun setPostRecordingFileNotification(enabled: Boolean) {
         preferences.setPostRecordingFileActionsNotificationEnabled(enabled)
+        refresh()
+    }
+
+    override fun setShowDeleteConfirmation(enabled: Boolean) {
+        preferences.setShowDeleteConfirmationEnabled(enabled)
         refresh()
     }
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -177,6 +177,7 @@
     <string name="placeholder_package_name_desc">Имя или название пакета приложения, инициировавшего вызов.</string>
     <string name="settings_post_recording_notification">Уведомление после записи</string>
     <string name="settings_post_recording_notification_description">Показать уведомление после завершения записи с помощью быстрых действий, таких как воспроизведение и удаление.</string>
+    <string name="settings_show_delete_confirmation">Запрашивать подтверждение перед удалением записи</string>
     <string name="settings_open_github_Wiki">Открыть Wiki</string>
     <string name="post_recording_notification_title">Управление записями</string>
     <string name="post_recording_notification_unknown_caller">Анонимный или неизвестный абонент</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
 
     <string name="settings_post_recording_notification">Post-Recording Notification</string>
     <string name="settings_post_recording_notification_description">Show a notification after the recording ends with quick actions like play and delete.</string>
+    <string name="settings_show_delete_confirmation">Show confirmation before deleting a recording</string>
     <string name="settings_vibration_enabled">Vibrate on start/stop</string>
     
     <string name="settings_auto_record_incoming">Automatically record incoming calls</string>

--- a/app/src/test/java/com/kitsumed/shizucallrecorder/CallPresentationRegressionTest.kt
+++ b/app/src/test/java/com/kitsumed/shizucallrecorder/CallPresentationRegressionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * ShizuCallRecorder: FOSS Call recording powered through ADB/Shizuku!
+ *  Copyright (C) 2026-present kitsumed (Med)
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.kitsumed.shizucallrecorder
+
+import com.kitsumed.shizucallrecorder.data.call.CallDirection
+import com.kitsumed.shizucallrecorder.data.call.EnrichedCallData
+import com.kitsumed.shizucallrecorder.services.callDetection.incall.normaliseCallHandleNumber
+import com.kitsumed.shizucallrecorder.services.recording.getPostRecordingCallerText
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CallPresentationRegressionTest {
+
+    @Test
+    fun notificationShowsContactNameWhenFilenameTemplateIncludesIt() {
+        val metadata = EnrichedCallData(
+            normalisedPhoneNumber = "+972501234567",
+            formattedE164Number = "+972501234567",
+            direction = CallDirection.INCOMING,
+            callerName = "Test Contact"
+        )
+
+        assertEquals(
+            "Test Contact (+972501234567)",
+            getPostRecordingCallerText(metadata, "{phone_number}_{caller_name}", "Unknown")
+        )
+    }
+
+    @Test
+    fun whatsappNumberWithoutPlusIsTreatedAsInternational() {
+        assertEquals(
+            "+972501234567",
+            normaliseCallHandleNumber("972501234567", "com.whatsapp")
+        )
+    }
+}

--- a/app/src/test/java/com/kitsumed/shizucallrecorder/services/recording/DeleteConfirmationPolicyTest.kt
+++ b/app/src/test/java/com/kitsumed/shizucallrecorder/services/recording/DeleteConfirmationPolicyTest.kt
@@ -1,0 +1,27 @@
+/*
+ * ShizuCallRecorder: FOSS Call recording powered through ADB/Shizuku!
+ *  Copyright (C) 2026-present kitsumed (Med)
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.kitsumed.shizucallrecorder.services.recording
+
+import com.kitsumed.shizucallrecorder.data.AppPreferences
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeleteConfirmationPolicyTest {
+
+    @Test
+    fun confirmationIsEnabledByDefault() {
+        assertTrue(AppPreferences.DefaultsValue.SHOW_DELETE_CONFIRMATION)
+    }
+
+    @Test
+    fun disabledConfirmationSkipsTheDialog() {
+        assertFalse(shouldShowDeleteConfirmation(false))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ shizuku-provider = "13.1.5"
 # Utility
 aboutlibraries = "14.2.1"
 libphonenumber = "9.0.35"
+junit = "4.13.2"
 
 [libraries]
 # AndroidX Core & Lifecycle
@@ -51,6 +52,7 @@ aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3",
 
 # Libphonenumber
 libphonenumber = { module = "com.googlecode.libphonenumber:libphonenumber", version.ref = "libphonenumber" }
+junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

- add a setting to require confirmation before deleting a recording, enabled by default
- show the contact name with the phone number in the post-call notification when the filename template includes `{caller_name}`
- preserve international WhatsApp and WhatsApp Business call handles that omit the leading `+`

## Root causes

- the delete notification action always displayed the confirmation dialog
- the post-call notification always used `getBestNumber()` and ignored the selected contact-name placeholder
- digit-only WhatsApp handles were parsed using the device region, so an Israeli `972...` number could become `+1 972...` on a US-region device

## Validation

- `testDebugUnitTest`
- `lintDebug`
- `assembleDebug`
