### PR TITLE
refractor(RecordingNotificationHelper): Show caller name in post-call notifications

### DIFF
--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingNotificationHelper.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingNotificationHelper.kt
@@ -233,13 +233,11 @@ class RecordingNotificationHelper(private val context: Context) {
     fun showPostCallNotification(fileUri: Uri, callMetadata: EnrichedCallData) {
         val manager = context.getSystemService(NotificationManager::class.java)
         val number = callMetadata.getBestNumber()
-        val callerName = callMetadata.callerName?.takeIf {
-            it.isNotBlank() && AppPreferences(context).getFileNameTemplate().contains(RecordingFileNameFormatter.FileNamePlaceholder.CALLER_NAME.tag)
-        }
         val callerText = when {
-            callerName != null && number.isNotEmpty() -> "$callerName ($number)"
-            callerName != null -> callerName
-            else -> number
+            callMetadata.callerName != null && number.isNotEmpty() -> "${callMetadata.callerName} ($number)"
+            callMetadata.callerName != null -> callMetadata.callerName
+            number.isNotEmpty() -> number
+            else -> context.getString(R.string.post_recording_notification_unknown_caller)
         }
 
         // Play action
@@ -274,7 +272,7 @@ class RecordingNotificationHelper(private val context: Context) {
             .setSmallIcon(R.drawable.ic_audio_file)
             .setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
             .setContentTitle(context.getString(R.string.post_recording_notification_title))
-            .setContentText(callerText.ifEmpty { context.getString(R.string.post_recording_notification_unknown_caller) })
+            .setContentText(callerText)
             .setAutoCancel(true)
             .addAction(android.R.drawable.ic_media_play, context.getString(R.string.general_play), playPendingIntent)
             .addAction(android.R.drawable.ic_menu_share, context.getString(R.string.general_share), sharePendingIntent)

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingNotificationHelper.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingNotificationHelper.kt
@@ -29,6 +29,7 @@ import androidx.core.app.NotificationCompat
 import com.kitsumed.shizucallrecorder.R
 import com.kitsumed.shizucallrecorder.data.AppPreferences
 import com.kitsumed.shizucallrecorder.data.call.EnrichedCallData
+import com.kitsumed.shizucallrecorder.utils.RecordingFileNameFormatter
 import com.kitsumed.shizucallrecorder.ui.theme.Green40
 
 class RecordingNotificationHelper(private val context: Context) {
@@ -231,6 +232,15 @@ class RecordingNotificationHelper(private val context: Context) {
      */
     fun showPostCallNotification(fileUri: Uri, callMetadata: EnrichedCallData) {
         val manager = context.getSystemService(NotificationManager::class.java)
+        val number = callMetadata.getBestNumber()
+        val callerName = callMetadata.callerName?.takeIf {
+            it.isNotBlank() && AppPreferences(context).getFileNameTemplate().contains(RecordingFileNameFormatter.FileNamePlaceholder.CALLER_NAME.tag)
+        }
+        val callerText = when {
+            callerName != null && number.isNotEmpty() -> "$callerName ($number)"
+            callerName != null -> callerName
+            else -> number
+        }
 
         // Play action
         val playIntent = Intent(Intent.ACTION_VIEW).apply {
@@ -264,7 +274,7 @@ class RecordingNotificationHelper(private val context: Context) {
             .setSmallIcon(R.drawable.ic_audio_file)
             .setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
             .setContentTitle(context.getString(R.string.post_recording_notification_title))
-            .setContentText(callMetadata.getBestNumber().takeIf { it.isNotEmpty() } ?: context.getString(R.string.post_recording_notification_unknown_caller))
+            .setContentText(callerText.ifEmpty { context.getString(R.string.post_recording_notification_unknown_caller) })
             .setAutoCancel(true)
             .addAction(android.R.drawable.ic_media_play, context.getString(R.string.general_play), playPendingIntent)
             .addAction(android.R.drawable.ic_menu_share, context.getString(R.string.general_share), sharePendingIntent)


### PR DESCRIPTION
This is the isolated contact-name change from #82.

## What changed

The post-call notification now shows `Caller Name (+123...)` when the filename template contains `{caller_name}`. Templates without that placeholder keep showing only the number.

The caller name was already available in `EnrichedCallData`; the notification previously ignored it.

## Validation

- `lintDebug`
- `assembleDebug`

Reference: [`NotificationCompat.Builder.setContentText`](https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder#setContentText(java.lang.CharSequence))

AI disclosure: OpenAI Codex assisted with implementation and validation; I reviewed the resulting diff.