### PR TITLE
fix(PhoneNumberManager): Best attemp at handling international numbers without a leading plus

### DIFF
--- a/app/src/main/java/com/kitsumed/shizucallrecorder/utils/PhoneNumberManager.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/utils/PhoneNumberManager.kt
@@ -77,12 +77,12 @@ class PhoneNumberManager private constructor(context: Context) {
     }
 
     /**
-     * Determines the device's country ISO code using a multi-step approach:
+     * Determines the device's country ISO code using a multistep approach:
      * 1. Network Country ISO: Based on the current cellular network, which reflects the user's physical location.
      * 2. SIM Country ISO: Based on the SIM card's home country, which is useful if the user is offline but has a SIM card.
      * 3. Locale Country: Based on the device's default locale, which serves as a fallback for tablets or devices in airplane mode without SIM cards.
      * @param context The context used to access the TelephonyManager. **Use the application context to avoid memory leaks**.
-     * @return The determined country ISO code in uppercase (e.g., "US", "GB"). If all methods fail, it will return an empty string.
+     * @return The determined country ISO code in lowercase (e.g., "us", "gb"). If all methods fail, it will return an empty string.
      */
     fun getDeviceCountryIso(): String {
         val telephonyManager = appContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
@@ -107,12 +107,14 @@ class PhoneNumberManager private constructor(context: Context) {
     suspend fun parsePhoneNumber(rawNumber: String, defaultRegion: String = getDeviceCountryIso()): Phonenumber.PhoneNumber? = withContext(Dispatchers.Default) {
         return@withContext try {
             val parsedNumber = phoneUtil.parse(rawNumber, defaultRegion.uppercase())
-            if (rawNumber.trimStart().startsWith("+") || phoneUtil.isPossibleNumber(parsedNumber)) {
+            // If the parsed number is valid in the selected region, return it. If not, attempt to make it international by adding a leading '+'.
+            if (phoneUtil.isValidNumber(parsedNumber)) {
                 parsedNumber
             } else {
-                runCatching {
-                    phoneUtil.parse("+${normalisePhoneNumber(rawNumber)}", null)
-                }.getOrNull()?.takeIf(phoneUtil::isPossibleNumber) ?: parsedNumber
+                // Prepend "+" and tell the library that it NEED to parse it as international ("ZZ" region code).
+                val internationalNumberStr = if (rawNumber.startsWith("+")) rawNumber else "+$rawNumber"
+                AppLogger.v("Parsed number ($rawNumber) is invalid in region ($defaultRegion), attempting to parse as international: $internationalNumberStr")
+                phoneUtil.parse(internationalNumberStr, "ZZ")
             }
         } catch (e: Exception) {
             AppLogger.e( "Error parsing phone number: ${e.message}", e)

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/utils/PhoneNumberManager.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/utils/PhoneNumberManager.kt
@@ -98,13 +98,22 @@ class PhoneNumberManager private constructor(context: Context) {
 
     /**
      * Parses a phone number string into a structured [Phonenumber.PhoneNumber] object using the specified default region.
+     * Numbers without a leading '+' are normally parsed using [defaultRegion]. If that interpretation is impossible,
+     * the number is retried as an international number because some call providers omit the '+'.
      * @param rawNumber The raw phone number string to parse (e.g., "202-555-0173").
      * @param defaultRegion The default region ISO code to use for parsing (e.g., "US"). If not provided, it will default to the device's country ISO.
      * @return A [Phonenumber.PhoneNumber] object if parsing is successful, or null if parsing fails.
      */
     suspend fun parsePhoneNumber(rawNumber: String, defaultRegion: String = getDeviceCountryIso()): Phonenumber.PhoneNumber? = withContext(Dispatchers.Default) {
         return@withContext try {
-            phoneUtil.parse(rawNumber, defaultRegion.uppercase())
+            val parsedNumber = phoneUtil.parse(rawNumber, defaultRegion.uppercase())
+            if (rawNumber.trimStart().startsWith("+") || phoneUtil.isPossibleNumber(parsedNumber)) {
+                parsedNumber
+            } else {
+                runCatching {
+                    phoneUtil.parse("+${normalisePhoneNumber(rawNumber)}", null)
+                }.getOrNull()?.takeIf(phoneUtil::isPossibleNumber) ?: parsedNumber
+            }
         } catch (e: Exception) {
             AppLogger.e( "Error parsing phone number: ${e.message}", e)
             null


### PR DESCRIPTION
This replaces the package-specific number handling from #82 with a shared parsing fix.

## What changed

`PhoneNumberManager.parsePhoneNumber()` now retries a number without `+` as an international number only when the normal device-region interpretation is impossible. The international result is used only when libphonenumber considers it possible.

## Root cause

libphonenumber can parse a digit-only international number as a national number for the device region even when that result is impossible. The later E.164 formatting step still formats that parsed value, producing the wrong country code.

This fix is shared by every call detection mode and does not depend on WhatsApp or `packageName`.

## Validation

- libphonenumber 9.0.35: `972541234567` on region `US` resolves to `+972541234567`
- control case: `2025550173` on region `US` remains `+12025550173`
- `lintDebug`
- `assembleDebug`

Reference: [`PhoneNumberUtil`](https://javadoc.io/doc/com.googlecode.libphonenumber/libphonenumber/9.0.35/com/google/i18n/phonenumbers/PhoneNumberUtil.html)

AI disclosure: OpenAI Codex assisted with implementation and validation; I reviewed the resulting diff.