### PR TITLE
Make recording delete confirmation optional

### DIFF
--- a/app/src/main/java/com/kitsumed/shizucallrecorder/data/AppPreferences.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/data/AppPreferences.kt
@@ -47,6 +47,7 @@ class AppPreferences(context: Context) {
         const val RECORD_THIRD_PARTY_CALLS = false
 
         const val POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED = false
+        const val SHOW_DELETE_CONFIRMATION = true
         const val AUTO_RECORD_INCOMING = false
         const val AUTO_RECORD_OUTGOING = false
 
@@ -101,6 +102,7 @@ class AppPreferences(context: Context) {
         RECORDING_FOLDER_URI("recording_folder_uri"),
         VIBRATION_ENABLED("vibration_enabled"),
         POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED ("post_recording_file_actions_notification_enabled"),
+        SHOW_DELETE_CONFIRMATION("show_delete_confirmation"),
         AUTO_RECORD_INCOMING("auto_record_incoming"),
         AUTO_RECORD_OUTGOING("auto_record_outgoing"),
         IGNORE_ANONYMOUS_INCOMING("ignore_anonymous_incoming"),
@@ -244,6 +246,12 @@ class AppPreferences(context: Context) {
     fun isPostRecordingFileActionsNotificationEnabled() = getBoolean(Key.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED, DefaultsValue.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED)
     /** Sets whether post-recording file actions notification is enabled. */
     fun setPostRecordingFileActionsNotificationEnabled(enabled: Boolean) = setBoolean(Key.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ENABLED, enabled)
+
+    /** Checks if deleting a recording requires confirmation. */
+    fun isShowDeleteConfirmationEnabled() = getBoolean(Key.SHOW_DELETE_CONFIRMATION, DefaultsValue.SHOW_DELETE_CONFIRMATION)
+
+    /** Sets whether deleting a recording requires confirmation. */
+    fun setShowDeleteConfirmationEnabled(enabled: Boolean) = setBoolean(Key.SHOW_DELETE_CONFIRMATION, enabled)
 
     /**
      * Gets the current preferred detection mode, automatically falling back

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/DeleteDialogConfirmationActivity.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/DeleteDialogConfirmationActivity.kt
@@ -17,10 +17,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
 import androidx.documentfile.provider.DocumentFile
 import com.kitsumed.shizucallrecorder.R
+import com.kitsumed.shizucallrecorder.data.AppPreferences
 import com.kitsumed.shizucallrecorder.utils.AppLogger
 
 /**
- * This is a simple activity that shows a confirmation dialog to the user before deleting a recording file.
+ * Deletes a recording file, optionally showing a confirmation dialog first.
  */
 class DeleteDialogConfirmationActivity : AppCompatActivity() {
 
@@ -34,22 +35,17 @@ class DeleteDialogConfirmationActivity : AppCompatActivity() {
             return
         }
 
+        if (!AppPreferences(this).isShowDeleteConfirmationEnabled()) {
+            deleteRecording(fileUri)
+            finish()
+            return
+        }
+
         AlertDialog.Builder(this)
             .setTitle(getString(R.string.delete_recording_confirmation_title))
             .setMessage(getString(R.string.delete_recording_confirmation_message))
             .setPositiveButton(getString(R.string.general_delete)) { dialog, _ ->
-                try {
-                    val deleted = DocumentFile.fromSingleUri(this, fileUri)?.delete() == true
-                    if (deleted) {
-                        Toast.makeText(this, getString(R.string.general_deleted), Toast.LENGTH_SHORT).show()
-                        // Remove the notifications from the notification tray since file no longer exists
-                        val manager = getSystemService(android.app.NotificationManager::class.java)
-                        manager.cancel(RecordingNotificationHelper.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ID)
-                    }
-                } catch (e: Exception) {
-                    AppLogger.e( "Failed to delete file: $fileUri", e)
-                    Toast.makeText(this, getString(R.string.delete_recording_confirmation_failed), Toast.LENGTH_LONG).show()
-                }
+                deleteRecording(fileUri)
                 dialog.dismiss()
             }
             .setNegativeButton(getString(R.string.general_cancel)) { dialog, _ ->
@@ -58,5 +54,19 @@ class DeleteDialogConfirmationActivity : AppCompatActivity() {
             .setOnDismissListener {
                 finish()
             }.show()
+    }
+
+    private fun deleteRecording(fileUri: Uri) {
+        try {
+            val deleted = DocumentFile.fromSingleUri(this, fileUri)?.delete() == true
+            if (deleted) {
+                Toast.makeText(this, getString(R.string.general_deleted), Toast.LENGTH_SHORT).show()
+                getSystemService(android.app.NotificationManager::class.java)
+                    .cancel(RecordingNotificationHelper.POST_RECORDING_FILE_ACTIONS_NOTIFICATION_ID)
+            }
+        } catch (e: Exception) {
+            AppLogger.e( "Failed to delete file: $fileUri", e)
+            Toast.makeText(this, getString(R.string.delete_recording_confirmation_failed), Toast.LENGTH_LONG).show()
+        }
     }
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
@@ -543,6 +543,7 @@ private fun RecordingSection(
     val recordThirdPartyCalls = remember(updateTrigger) { preferences.isRecordThirdPartyCallsEnabled() }
     val fileNameFormat = remember(updateTrigger) { preferences.getFileNameTemplate() }
     val postRecordingFileNotifications = remember(updateTrigger) { preferences.isPostRecordingFileActionsNotificationEnabled() }
+    val showDeleteConfirmation = remember(updateTrigger) { preferences.isShowDeleteConfirmationEnabled() }
     val isVibrationEnabled = remember(updateTrigger) { preferences.isVibrationEnabled() }
     val autoRecordIncoming = remember(updateTrigger) { preferences.isAutoRecordIncomingEnabled() }
     val autoRecordOutgoing = remember(updateTrigger) { preferences.isAutoRecordOutgoingEnabled() }
@@ -652,6 +653,12 @@ private fun RecordingSection(
             description = stringResource(R.string.settings_post_recording_notification_description),
             checked = postRecordingFileNotifications,
             onCheckedChange = { actions.setPostRecordingFileNotification(it) }
+        )
+
+        ToggleListItem(
+            label = stringResource(R.string.settings_show_delete_confirmation),
+            checked = showDeleteConfirmation,
+            onCheckedChange = { actions.setShowDeleteConfirmation(it) }
         )
 
         ToggleListItem(
@@ -1222,6 +1229,7 @@ private fun SettingsScreenPreview() {
             override fun setCallDetectionMode(mode: CallDetectionMode) {}
             override fun setRecordThirdPartyCalls(enabled: Boolean) {}
             override fun setPostRecordingFileNotification(enabled: Boolean) {}
+            override fun setShowDeleteConfirmation(enabled: Boolean) {}
             override fun setOverlayEnabled(enabled: Boolean) {}
         }
 

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/viewmodels/SettingsViewModel.kt
@@ -77,6 +77,7 @@ interface SettingsActions {
     fun setCallDetectionMode(mode: CallDetectionMode)
     fun setRecordThirdPartyCalls(enabled: Boolean)
     fun setPostRecordingFileNotification(enabled: Boolean)
+    fun setShowDeleteConfirmation(enabled: Boolean)
     fun setOverlayEnabled(enabled: Boolean)
 }
 
@@ -422,6 +423,11 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
      */
     override fun setPostRecordingFileNotification(enabled: Boolean) {
         preferences.setPostRecordingFileActionsNotificationEnabled(enabled)
+        refresh()
+    }
+
+    override fun setShowDeleteConfirmation(enabled: Boolean) {
+        preferences.setShowDeleteConfirmationEnabled(enabled)
         refresh()
     }
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -177,6 +177,7 @@
     <string name="placeholder_package_name_desc">Имя или название пакета приложения, инициировавшего вызов.</string>
     <string name="settings_post_recording_notification">Уведомление после записи</string>
     <string name="settings_post_recording_notification_description">Показать уведомление после завершения записи с помощью быстрых действий, таких как воспроизведение и удаление.</string>
+    <string name="settings_show_delete_confirmation">Запрашивать подтверждение перед удалением записи</string>
     <string name="settings_open_github_Wiki">Открыть Wiki</string>
     <string name="post_recording_notification_title">Управление записями</string>
     <string name="post_recording_notification_unknown_caller">Анонимный или неизвестный абонент</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
 
     <string name="settings_post_recording_notification">Post-Recording Notification</string>
     <string name="settings_post_recording_notification_description">Show a notification after the recording ends with quick actions like play and delete.</string>
+    <string name="settings_show_delete_confirmation">Show confirmation before deleting a recording</string>
     <string name="settings_vibration_enabled">Vibrate on start/stop</string>
     
     <string name="settings_auto_record_incoming">Automatically record incoming calls</string>


### PR DESCRIPTION
This is the isolated delete-confirmation change from #82.

## What changed

- added a setting to show confirmation before deleting a recording
- kept confirmation enabled by default
- reused the existing deletion path whether confirmation is shown or skipped

## Why

The default remains the safe behavior. Users who intentionally delete recordings from the post-call notification can explicitly opt out of the second confirmation step for repeated cleanup. The setting only affects the existing Delete action; it does not introduce automatic deletion.

## Validation

- `lintDebug`
- `assembleDebug`

Reference: [Add action buttons to a notification](https://developer.android.com/develop/ui/views/notifications/build-notification#Actions)

AI disclosure: OpenAI Codex assisted with implementation and validation; I reviewed the resulting diff.