### PR TITLE
fix(ui): handle edge-to-edge system bars and icon contrast

### DIFF
--- a/app/src/main/java/com/kitsumed/shizucallrecorder/AppNavigationScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/AppNavigationScreen.kt
@@ -36,8 +36,7 @@ import com.kitsumed.shizucallrecorder.ui.screens.DisclaimerScreen
 import com.kitsumed.shizucallrecorder.ui.screens.PermissionsScreen
 import com.kitsumed.shizucallrecorder.ui.screens.SettingsScreen
 import com.kitsumed.shizucallrecorder.ui.screens.SponsorScreen
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
-import com.kitsumed.shizucallrecorder.ui.theme.SystemBarIconAppearance
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 import com.kitsumed.shizucallrecorder.ui.viewmodels.AppNavigationViewModel
 import com.kitsumed.shizucallrecorder.ui.viewmodels.SettingsViewModel
 
@@ -113,10 +112,8 @@ fun AppNavigationScreen() {
     }
     val dynamicColor = preferences.isDynamicColorEnabled()
 
-    SystemBarIconAppearance(darkTheme)
-
     // -------- Show the right screen
-    ShizucallrecorderTheme(darkTheme = darkTheme, dynamicColor = dynamicColor) {
+    ShizuCallRecorderTheme(darkTheme = darkTheme, dynamicColor = dynamicColor) {
         AnimatedContent(
             targetState = screenState,
             transitionSpec = {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/AppNavigationScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/AppNavigationScreen.kt
@@ -37,6 +37,7 @@ import com.kitsumed.shizucallrecorder.ui.screens.PermissionsScreen
 import com.kitsumed.shizucallrecorder.ui.screens.SettingsScreen
 import com.kitsumed.shizucallrecorder.ui.screens.SponsorScreen
 import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.SystemBarIconAppearance
 import com.kitsumed.shizucallrecorder.ui.viewmodels.AppNavigationViewModel
 import com.kitsumed.shizucallrecorder.ui.viewmodels.SettingsViewModel
 
@@ -111,6 +112,8 @@ fun AppNavigationScreen() {
         AppPreferences.ThemeMode.SYSTEM -> isSystemInDarkTheme()
     }
     val dynamicColor = preferences.isDynamicColorEnabled()
+
+    SystemBarIconAppearance(darkTheme)
 
     // -------- Show the right screen
     ShizucallrecorderTheme(darkTheme = darkTheme, dynamicColor = dynamicColor) {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/MainActivity.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/MainActivity.kt
@@ -9,6 +9,7 @@
 package com.kitsumed.shizucallrecorder
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 
@@ -22,6 +23,7 @@ import androidx.appcompat.app.AppCompatActivity
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             AppNavigationScreen()
         }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingOverlayController.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/services/recording/RecordingOverlayController.kt
@@ -40,7 +40,7 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.kitsumed.shizucallrecorder.data.AppPreferences
 import com.kitsumed.shizucallrecorder.system.permissions.PermissionChecks
 import com.kitsumed.shizucallrecorder.ui.common.RecordingOverlay
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 import kotlin.math.max
 import kotlin.math.min
 
@@ -90,7 +90,7 @@ class RecordingOverlayController(private val context: Context) {
             // State false -> true for the animation
             val isVisible = remember { MutableTransitionState(false).apply { targetState = true } }
 
-            ShizucallrecorderTheme(darkTheme = darkTheme, dynamicColor = dynamicColor) {
+            ShizuCallRecorderTheme(darkTheme = darkTheme, dynamicColor = dynamicColor) {
                 AnimatedVisibility(
                     visibleState = isVisible,
                     enter = slideInHorizontally(

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/ContactSelectionDialog.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/ContactSelectionDialog.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.kitsumed.shizucallrecorder.R
@@ -338,7 +338,7 @@ fun PreviewContactSelectionDialog() {
     )
     val selectedContacts = setOf("2")
 
-    ShizucallrecorderTheme(darkTheme = true) {
+    ShizuCallRecorderTheme(darkTheme = true) {
         ContactSelectionContent(
             title = stringResource(R.string.settings_select_contacts, selectedContacts.count()),
             contacts = dummyContacts,

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/DropdownComponents.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/DropdownComponents.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.*
 import androidx.compose.ui.tooling.preview.Preview
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 
 /**
  * A key/label/description/etc... data class used to populate dropdown menus.
@@ -117,7 +117,7 @@ fun PreviewM3DropdownField() {
         OptionItem("opt2", "Another Option", "Description for option 2"),
         OptionItem("opt3", "Disabled Option", "This cannot be selected", enabled = false)
     )
-    ShizucallrecorderTheme(darkTheme = false) {
+    ShizuCallRecorderTheme(darkTheme = false) {
         Surface {
             M3DropdownField(
                 label = "Select an option",

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/FileNameFormatDialog.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/FileNameFormatDialog.kt
@@ -45,7 +45,7 @@ import com.kitsumed.shizucallrecorder.data.call.CallDirection
 import com.kitsumed.shizucallrecorder.data.call.EnrichedCallData
 import com.kitsumed.shizucallrecorder.integrations.scrcpy.ScrcpyAudioCodec
 import com.kitsumed.shizucallrecorder.services.callDetection.CallDetectionMode
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 import com.kitsumed.shizucallrecorder.utils.RecordingFileNameFormatter
 
 /**
@@ -170,7 +170,7 @@ fun FileNameFormatDialog(
 @Preview(showBackground = true)
 @Composable
 private fun SettingsScreenPreview() {
-    ShizucallrecorderTheme(darkTheme = false) {
+    ShizuCallRecorderTheme(darkTheme = false) {
         Surface(modifier = Modifier.fillMaxSize()) {
             FileNameFormatDialog(
                 initialFormat = AppPreferences.DefaultsValue.FILE_NAME_TEMPLATE,

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/RecordingOverlay.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/RecordingOverlay.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kitsumed.shizucallrecorder.R
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 
 /**
  * The floating overlay UI for controlling the recording.
@@ -184,7 +184,7 @@ fun RecordingOverlay(
 @Preview(name = "Standby")
 @Composable
 private fun PreviewRecordingOverlayStandby() {
-    ShizucallrecorderTheme(darkTheme = false) {
+    ShizuCallRecorderTheme(darkTheme = false) {
         RecordingOverlay(isRecordingActive = false, isRecordingPaused = false, onActionClick = {}, onDragY = {}, onDragEnd = {})
     }
 }
@@ -192,7 +192,7 @@ private fun PreviewRecordingOverlayStandby() {
 @Preview(name = "Recording")
 @Composable
 private fun PreviewRecordingOverlayRecording() {
-    ShizucallrecorderTheme(darkTheme = false) {
+    ShizuCallRecorderTheme(darkTheme = false) {
         RecordingOverlay(isRecordingActive = true, isRecordingPaused = false, onActionClick = {}, onDragY = {}, onDragEnd = {})
     }
 }
@@ -200,7 +200,7 @@ private fun PreviewRecordingOverlayRecording() {
 @Preview(name = "Paused")
 @Composable
 private fun PreviewRecordingOverlayPaused() {
-    ShizucallrecorderTheme(darkTheme = false) {
+    ShizuCallRecorderTheme(darkTheme = false) {
         RecordingOverlay(isRecordingActive = true, isRecordingPaused = true, onActionClick = {}, onDragY = {}, onDragEnd = {})
     }
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/ToggleListItem.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/common/ToggleListItem.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 
 /** A list row with a switch. Tapping anywhere on the row toggles the switch.
  *
@@ -56,7 +56,7 @@ fun ToggleListItem(
 @Preview(showBackground = true)
 @Composable
 private fun PreviewToggleListItem() {
-    ShizucallrecorderTheme(darkTheme = false) {
+    ShizuCallRecorderTheme(darkTheme = false) {
         Surface(
             modifier = Modifier.fillMaxWidth()
         ) {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/DisclaimerScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/DisclaimerScreen.kt
@@ -62,7 +62,7 @@ import androidx.compose.ui.unit.dp
 import com.kitsumed.shizucallrecorder.AppUrls
 import com.kitsumed.shizucallrecorder.BuildConfig
 import com.kitsumed.shizucallrecorder.R
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 
@@ -98,7 +98,6 @@ fun DisclaimerScreen(onContinue: () -> Unit, modifier: Modifier = Modifier) {
         }
     }
 
-    // Surface ensures the Material 3 background colour fills the screen correctly.
     Surface(
         modifier = Modifier
             .fillMaxSize(),
@@ -268,7 +267,7 @@ fun HyperlinkText(
 @Preview(showBackground = true)
 @Composable
 private fun DisclaimerScreenPreview() {
-    ShizucallrecorderTheme {
+    ShizuCallRecorderTheme {
         DisclaimerScreen(onContinue = {})
     }
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/DisclaimerScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/DisclaimerScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
@@ -101,13 +101,13 @@ fun DisclaimerScreen(onContinue: () -> Unit, modifier: Modifier = Modifier) {
     // Surface ensures the Material 3 background colour fills the screen correctly.
     Surface(
         modifier = Modifier
-            .navigationBarsPadding()
             .fillMaxSize(),
         color = MaterialTheme.colorScheme.background,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .safeDrawingPadding()
                 .padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp)
         ) {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/PermissionsScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/PermissionsScreen.kt
@@ -297,13 +297,13 @@ fun PermissionsContent(
 ) {
     Surface(
         modifier = modifier
-            .navigationBarsPadding()
             .fillMaxSize(),
         color = MaterialTheme.colorScheme.background
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .safeDrawingPadding()
                 .padding(horizontal = 24.dp)
                 .padding(top = 24.dp, bottom = 16.dp)
         ) {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/PermissionsScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/PermissionsScreen.kt
@@ -57,7 +57,7 @@ import com.kitsumed.shizucallrecorder.system.openGithubReportIssue
 import com.kitsumed.shizucallrecorder.ui.common.M3DropdownField
 import com.kitsumed.shizucallrecorder.ui.common.OptionItem
 import com.kitsumed.shizucallrecorder.ui.common.ToggleListItem
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 import com.kitsumed.shizucallrecorder.ui.viewmodels.PermissionsViewModel
 import com.kitsumed.shizucallrecorder.utils.AppLogger
 import kotlinx.coroutines.Dispatchers
@@ -507,7 +507,7 @@ private fun PermissionCard(
 @Preview(showBackground = true)
 @Composable
 private fun PermissionsScreenPreview() {
-    ShizucallrecorderTheme(darkTheme = false) {
+    ShizuCallRecorderTheme(darkTheme = false) {
         PermissionsContent(
             status = OnboardingStatus.Status(
                 disclaimerAccepted = true,

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
@@ -173,12 +173,13 @@ fun SettingsContent(
 ) {
     Surface(
         modifier = modifier
-            .fillMaxSize()
-            .navigationBarsPadding(),
+            .fillMaxSize(),
         color = MaterialTheme.colorScheme.background
     ) {
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .safeDrawingPadding(),
             contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SettingsScreen.kt
@@ -72,7 +72,7 @@ import com.kitsumed.shizucallrecorder.ui.common.FileNameFormatDialog
 import com.kitsumed.shizucallrecorder.ui.common.M3DropdownField
 import com.kitsumed.shizucallrecorder.ui.common.OptionItem
 import com.kitsumed.shizucallrecorder.ui.common.ToggleListItem
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 import com.kitsumed.shizucallrecorder.ui.viewmodels.ContactPickerState
 import com.kitsumed.shizucallrecorder.ui.viewmodels.ContactPickerType
 import com.kitsumed.shizucallrecorder.ui.viewmodels.ContactPickerViewModel
@@ -178,9 +178,11 @@ fun SettingsContent(
     ) {
         LazyColumn(
             modifier = Modifier
-                .fillMaxSize()
-                .safeDrawingPadding(),
-            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
+                .fillMaxSize(),
+            // Equivalent to .safeDrawingPadding() but allow UI to extend behind the status bar when scrolling
+            contentPadding = WindowInsets.safeDrawing
+                .add(WindowInsets(left = 20.dp, right = 20.dp, top = 0.dp, bottom = 0.dp))
+                .asPaddingValues(),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
             item {
@@ -205,6 +207,7 @@ fun SettingsContent(
             item { SecuritySection(preferences, updateTrigger, actions) }
             item { VisualSection(preferences, updateTrigger, actions) }
             item { DebugSection(preferences, updateTrigger, actions, onExportLogs) }
+            item {  } // extra padding at bottom
         }
     }
 
@@ -1190,7 +1193,7 @@ private fun DebugActionGrid(actions: SettingsActions) {
 @Preview(showBackground = true)
 @Composable
 private fun SettingsScreenPreview() {
-    ShizucallrecorderTheme(darkTheme = false, dynamicColor = false) {
+    ShizuCallRecorderTheme(darkTheme = false, dynamicColor = false) {
         val mockContext = LocalContext.current
         val dummyPreferences = AppPreferences(mockContext)
         val dummyActions = object : SettingsActions {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SponsorScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SponsorScreen.kt
@@ -133,13 +133,13 @@ fun SponsorScreen(
 
     Surface(
         modifier = modifier
-            .navigationBarsPadding()
             .fillMaxSize(),
         color = MaterialTheme.colorScheme.background,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .safeDrawingPadding()
                 .padding(horizontal = 24.dp)
                 .padding(top = 24.dp, bottom = 16.dp),
         ) {

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SponsorScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SponsorScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -49,6 +50,7 @@ import com.kitsumed.shizucallrecorder.R
 import com.kitsumed.shizucallrecorder.system.openGithub
 import com.kitsumed.shizucallrecorder.system.openGithubSponsor
 import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
+import com.kitsumed.shizucallrecorder.ui.theme.SystemBarIconAppearance
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -69,6 +71,10 @@ fun SponsorScreen(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    SystemBarIconAppearance(
+        darkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f
+    )
+
     val context = LocalContext.current
     val scrollState = rememberScrollState()
 

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SponsorScreen.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/screens/SponsorScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -49,8 +48,7 @@ import androidx.compose.ui.unit.dp
 import com.kitsumed.shizucallrecorder.R
 import com.kitsumed.shizucallrecorder.system.openGithub
 import com.kitsumed.shizucallrecorder.system.openGithubSponsor
-import com.kitsumed.shizucallrecorder.ui.theme.ShizucallrecorderTheme
-import com.kitsumed.shizucallrecorder.ui.theme.SystemBarIconAppearance
+import com.kitsumed.shizucallrecorder.ui.theme.ShizuCallRecorderTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -71,10 +69,6 @@ fun SponsorScreen(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    SystemBarIconAppearance(
-        darkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f
-    )
-
     val context = LocalContext.current
     val scrollState = rememberScrollState()
 
@@ -145,9 +139,7 @@ fun SponsorScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .safeDrawingPadding()
                 .padding(horizontal = 24.dp)
-                .padding(top = 24.dp, bottom = 16.dp),
         ) {
             // Header
             StaggeredFadePop(index = 0) {
@@ -155,7 +147,8 @@ fun SponsorScreen(
                     text = stringResource(R.string.sponsor_title),
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onBackground
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.statusBarsPadding().padding(top = 24.dp)
                 )
             }
 
@@ -165,23 +158,41 @@ fun SponsorScreen(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    // The fading edge mask logic
                     .graphicsLayer { alpha = 0.99f } // Forces composition layer for BlendMode
                     .drawWithCache {
-                        val fadeHeight = 66.dp.toPx() // Starts a bit earlier
-                        val fadeBrush = Brush.verticalGradient(
-                            // Adding a midway stop creates a progressive, curved fade out
+                        val topFadeHeight = 48.dp.toPx()
+                        val bottomFadeHeight = 48.dp.toPx()
+
+                        // --- TOP FADE BRUSH ---
+                        // Only apply a real fade if the user has scrolled down (scroll != 0).
+                        val isScrolled = scrollState.value > 0
+                        val topFadeBrush = Brush.verticalGradient(
+                            0.0f to if (isScrolled) Color.Transparent else Color.Black,
+                            0.6f to if (isScrolled) Color.Black.copy(alpha = 0.4f) else Color.Black,
+                            1.0f to Color.Black,
+                            startY = 0f,
+                            endY = topFadeHeight
+                        )
+
+                        // --- BOTTOM FADE BRUSH ---
+                        val bottomFadeBrush = Brush.verticalGradient(
                             0.0f to Color.Black,
-                            0.4f to Color.Black.copy(alpha = 0.4f),
                             1.0f to Color.Transparent,
-                            startY = (size.height - fadeHeight).coerceAtLeast(0f),
+                            startY = (size.height - bottomFadeHeight).coerceAtLeast(0f),
                             endY = size.height
                         )
+
                         onDrawWithContent {
                             drawContent()
+                            // Blend the Top Mask
                             drawRect(
-                                brush = fadeBrush,
-                                blendMode = BlendMode.DstIn // Keeps content where mask is solid, fades where transparent
+                                brush = topFadeBrush,
+                                blendMode = BlendMode.DstIn
+                            )
+                            // Blend the Bottom Mask
+                            drawRect(
+                                brush = bottomFadeBrush,
+                                blendMode = BlendMode.DstIn
                             )
                         }
                     }
@@ -270,7 +281,11 @@ fun SponsorScreen(
             }
 
             // Footer / Actions
-            Column {
+            Column(
+                modifier = Modifier
+                    .navigationBarsPadding()
+                    .padding(bottom = 16.dp)
+            ) {
                 StaggeredFadePop(index = 8) {
                     HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
                 }
@@ -561,7 +576,7 @@ private fun StaggeredFadePop(
 @Preview(showBackground = true)
 @Composable
 private fun SponsorScreenPreview() {
-    ShizucallrecorderTheme(darkTheme = true, dynamicColor = true) {
+    ShizuCallRecorderTheme(darkTheme = true, dynamicColor = true) {
         SponsorScreen(onDismiss = {})
     }
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/theme/Theme.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/theme/Theme.kt
@@ -9,8 +9,6 @@
 package com.kitsumed.shizucallrecorder.ui.theme
 
 import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -22,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
@@ -57,20 +54,34 @@ private val LightColorScheme = lightColorScheme(
 )
 
 @Composable
-fun ShizucallrecorderTheme(
+fun ShizuCallRecorderTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
+    val context = LocalContext.current
+    val view = LocalView.current
+
+    // Dynamic color scheme
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
+    }
+
+    // System Bar icon theme sync
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as? Activity)?.window
+            if (window != null) {
+                val insetsController = WindowCompat.getInsetsController(window, view)
+                insetsController.isAppearanceLightStatusBars = !darkTheme
+                insetsController.isAppearanceLightNavigationBars = !darkTheme
+            }
+        }
     }
 
     MaterialTheme(
@@ -78,35 +89,4 @@ fun ShizucallrecorderTheme(
         typography = Typography,
         content = content
     )
-}
-
-/**
- * Synchronizes status and navigation bar icon contrast with the app theme for both Activity
- * windows and full-screen Dialog windows.
- *
- * @see <a href="https://developer.android.com/develop/ui/views/layout/edge-to-edge">Edge-to-edge layouts</a>
- * @see <a href="https://developer.android.com/develop/ui/compose/system/insets">Window insets in Compose</a>
- * @see <a href="https://developer.android.com/reference/androidx/core/view/WindowInsetsControllerCompat">WindowInsetsControllerCompat</a>
- */
-@Composable
-fun SystemBarIconAppearance(darkTheme: Boolean) {
-    val context = LocalContext.current
-    val view = LocalView.current
-
-    SideEffect {
-        val window = (view.parent as? DialogWindowProvider)?.window
-            ?: context.findActivity()?.window
-            ?: return@SideEffect
-
-        WindowCompat.getInsetsController(window, view).apply {
-            isAppearanceLightStatusBars = !darkTheme
-            isAppearanceLightNavigationBars = !darkTheme
-        }
-    }
-}
-
-private tailrec fun Context.findActivity(): Activity? = when (this) {
-    is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> null
 }

--- a/app/src/main/java/com/kitsumed/shizucallrecorder/ui/theme/Theme.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/ui/theme/Theme.kt
@@ -8,6 +8,9 @@
 
 package com.kitsumed.shizucallrecorder.ui.theme
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -16,7 +19,11 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
     primary = Green80,
@@ -71,4 +78,35 @@ fun ShizucallrecorderTheme(
         typography = Typography,
         content = content
     )
+}
+
+/**
+ * Synchronizes status and navigation bar icon contrast with the app theme for both Activity
+ * windows and full-screen Dialog windows.
+ *
+ * @see <a href="https://developer.android.com/develop/ui/views/layout/edge-to-edge">Edge-to-edge layouts</a>
+ * @see <a href="https://developer.android.com/develop/ui/compose/system/insets">Window insets in Compose</a>
+ * @see <a href="https://developer.android.com/reference/androidx/core/view/WindowInsetsControllerCompat">WindowInsetsControllerCompat</a>
+ */
+@Composable
+fun SystemBarIconAppearance(darkTheme: Boolean) {
+    val context = LocalContext.current
+    val view = LocalView.current
+
+    SideEffect {
+        val window = (view.parent as? DialogWindowProvider)?.window
+            ?: context.findActivity()?.window
+            ?: return@SideEffect
+
+        WindowCompat.getInsetsController(window, view).apply {
+            isAppearanceLightStatusBars = !darkTheme
+            isAppearanceLightNavigationBars = !darkTheme
+        }
+    }
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
 }


### PR DESCRIPTION
## Summary

This PR fixes two edge-to-edge UI issues:

- Screen content could be drawn underneath the status bar because the full-screen Compose layouts only applied navigation bar padding.
- Status and navigation bar icons remained light in the app's light theme, making them difficult to see against the light background.

The change applies safe drawing insets to the content of the Disclaimer, Permissions, Settings, and Sponsor screens while allowing their background surfaces to continue drawing behind the system bars.

It also explicitly enables edge-to-edge mode and synchronizes the status/navigation bar icon appearance with the active app theme. The icon handling supports both the main Activity window and the separate window used by the full-screen Sponsor dialog.

No new dependencies were added.

## Screenshots

### Before: status bar overlapping content on a physical device

<img width="287" height="640" alt="图片" src="https://github.com/user-attachments/assets/5bec4a66-a5e8-4630-a0eb-79767063620e" />

The Settings title was rendered underneath the status bar.

### Before: system bar icons in light mode on the API 37 emulator

<img width="287" height="640" alt="图片" src="https://github.com/user-attachments/assets/dacf755d-0933-493c-96ef-ca8a69af52f4" />

After extending the page background behind the system bars, the icons still used their light appearance and had insufficient contrast against the light background.

### After: light theme

<img width="287" height="640" alt="图片" src="https://github.com/user-attachments/assets/76f25421-7309-4aea-9abb-c90060bdf158" />

The content respects the safe drawing area, the page background extends behind the system bars, and the system bar icons use their dark appearance.

### After: dark theme

<img width="287" height="640" alt="图片" src="https://github.com/user-attachments/assets/cfe8d12d-57ae-4a66-965a-b9c6d13ff11e" />

The same edge-to-edge layout is preserved while the system bar icons switch back to their light appearance.

## Edge-to-edge behavior

For apps targeting recent Android versions, edge-to-edge causes the app window to draw behind the system bars. The app is responsible for applying appropriate window insets to interactive content while allowing backgrounds to extend into those areas.

This PR uses Compose safe drawing insets for content placement instead of opting out of edge-to-edge behavior.

Relevant Android documentation:

- [Edge-to-edge layouts](https://developer.android.com/develop/ui/views/layout/edge-to-edge)
- [Window insets in Compose](https://developer.android.com/develop/ui/compose/system/insets)
- [WindowInsetsControllerCompat](https://developer.android.com/reference/androidx/core/view/WindowInsetsControllerCompat)

## Testing

Tested with a debug build on an API 37 emulator at 1280 × 2856:

- Verified the Settings and Permissions screens.
- Verified that content remains outside the status and navigation bar safe areas.
- Verified that the page background extends behind both system bars.
- Verified system bar icon contrast in light and dark themes.
- Verified icon contrast in the full-screen Sponsor dialog.
- Ran `:app:assembleDebug` successfully.

## Personal usage feedback

As a Pixel user in mainland China, I use the device in a region where Google provides very limited localization and user-experience support. Call recording is a standard built-in feature on many phones sold in China. Although Xposed and root-based solutions have made it possible to add this functionality to Pixel devices, the side effects of using Xposed or root have become increasingly significant as Android has grown more restrictive.

That makes the non-root approach used by this project especially valuable. I have been using ShizuCallRecorder for about two months, and it has reliably recorded my calls. Everything has worked correctly for me, apart from the UI being obscured by the status bar. XD

Thank you for discovering this non-root approach and for learning the Android development knowledge needed to build and maintain this app. I hope contributions like this can provide a small amount of help in keeping Android useful and open as the platform becomes increasingly restrictive.

## AI assistance disclosure

This contribution was made at my request. I explicitly authorized Codex to investigate and implement the changes and, after approval, to create the pull request using my GitHub account.

Because I am not confident writing in English, I provided the original descriptions in Chinese and used ChatGPT/Codex to translate and polish the PR text. I personally reviewed and approved the implementation, emulator test results, screenshots, and final PR description before submission.