### PR TITLE
fix(SafHelper): delete orphaned empty file when FD open fails after creation

### DIFF
--- a/app/src/main/java/com/kitsumed/shizucallrecorder/system/storage/SafHelper.kt
+++ b/app/src/main/java/com/kitsumed/shizucallrecorder/system/storage/SafHelper.kt
@@ -67,7 +67,12 @@ object SafHelper {
         val newFile = currentDir.createFile(mimeType, fileName) ?: return null
 
         // Open the file in read-write mode so MediaMuxer can seek back to write headers.
-        val fileDescriptor = context.contentResolver.openFileDescriptor(newFile.uri, "rw") ?: return null
+        val fileDescriptor = context.contentResolver.openFileDescriptor(newFile.uri, "rw") ?: run {
+            // The document was created but could not be opened (e.g. transient SAF/DocumentsProvider glitch).
+            // Delete it so we don't leave an orphaned, untracked empty file in the user's recordings folder.
+            newFile.delete()
+            return null
+        }
         val displayName = "${rootDir.name}/${filePath.trimStart('/')}"
         return SafResult(newFile.uri, fileDescriptor, displayName)
     }


### PR DESCRIPTION
## Summary
- Reconciled a stale local branch against upstream `main` (fast-forward, no unique prior commits) after full inspection of the recording/call-detection/permission pipeline.
- Found and fixed one genuine bug in `SafHelper.createAudioFile()`: if `ContentResolver.openFileDescriptor()` fails after the SAF document was already created via `DocumentFile.createFile()`, the code returned `null` without deleting the just-created document, leaving an orphaned, empty, untracked file behind in the user's chosen recordings folder on every such failure. The fix deletes the orphaned `DocumentFile` before returning `null`.

## Testing
- `SKIP_SIGNING=true ./gradlew assembleDebug --stacktrace --no-daemon` — BUILD SUCCESSFUL.
- Not tested on a physical device: the actual `openFileDescriptor` failure path (would require forcing a transient SAF/DocumentsProvider error), and a general end-to-end recording session sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8GvrjdRj8AM6ag4rsGsbH